### PR TITLE
fix(router): role-based route guards (P0)

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -109,8 +109,10 @@ test.describe('Autenticación', () => {
     await page.goto('/');
     await page.waitForURL(/\/(home|dashboard|admin)/, { timeout: 15000 });
 
-    // Abrir dropdown del usuario (clic en el avatar del navbar)
-    await page.locator('nav img[alt]').click();
+    // Abrir dropdown del usuario (clic en el trigger del navbar).
+    // Se usa data-testid porque el avatar puede ser <img> o el fallback de
+    // inicial (<div>) cuando el usuario no tiene foto, como los usuarios E2E.
+    await page.getByTestId('user-menu-trigger').click();
     await page.getByText('Cerrar Sesión').click();
 
     await expect(page).toHaveURL('/login', { timeout: 10000 });

--- a/e2e/authorization.spec.ts
+++ b/e2e/authorization.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test';
+import { apiLogin, apiRegisterAndLogin } from './helpers/api';
+import { injectAuth } from './helpers/auth';
+
+/**
+ * Tests de autorización por rol: verifica que cada rol sea redirigido al landing
+ * correspondiente cuando intenta acceder a una ruta fuera de sus permisos, y que
+ * las rutas permitidas no generen redirecciones.
+ *
+ * Cuentas seed utilizadas:
+ *   admin       / Admin123!   → ADMINISTRATOR
+ *   seed-mentor / Mentor123!  → MENTOR
+ *   steve-wozniak / Dev123!   → RECRUITER
+ *   authz_dev_user (registrado en beforeAll) → DEV
+ */
+
+const PREFIX = 'authz';
+
+const DEV_USER = {
+  username: `${PREFIX}_dev_user`,
+  email: `${PREFIX}_dev_user@e2e.test`,
+  password: 'Password123!',
+  firstName: 'Authz',
+  lastName: 'DevUser',
+};
+
+let adminToken: string;
+let mentorToken: string;
+let recruiterToken: string;
+let devToken: string;
+
+test.describe('Autorización por rol', () => {
+  test.beforeAll(async ({ request }) => {
+    // Seed accounts must exist; if any login fails the error propagates and the
+    // suite fails loudly instead of producing silent skips / false-greens.
+    adminToken = await apiLogin(request, { username: 'admin', password: 'Admin123!' });
+    mentorToken = await apiLogin(request, { username: 'seed-mentor', password: 'Mentor123!' });
+    recruiterToken = await apiLogin(request, { username: 'steve-wozniak', password: 'Dev123!' });
+
+    // DEV uses a dynamically registered account with a login fallback.
+    devToken = await apiRegisterAndLogin(request, DEV_USER).catch(async () =>
+      apiLogin(request, { username: DEV_USER.username, password: DEV_USER.password })
+    );
+  });
+
+  // ── RECRUITER ──────────────────────────────────────────────────────────────
+  // El landing de RECRUITER es /recruiter-dashboard.
+
+  test('RECRUITER → /admin redirige a /recruiter-dashboard', async ({ page }) => {
+    await injectAuth(page, recruiterToken);
+    await page.goto('/admin');
+    await expect(page).toHaveURL('/recruiter-dashboard', { timeout: 10000 });
+  });
+
+  test('RECRUITER → /dashboard redirige a /recruiter-dashboard', async ({ page }) => {
+    await injectAuth(page, recruiterToken);
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL('/recruiter-dashboard', { timeout: 10000 });
+  });
+
+  test('RECRUITER → /home redirige a /recruiter-dashboard', async ({ page }) => {
+    await injectAuth(page, recruiterToken);
+    await page.goto('/home');
+    await expect(page).toHaveURL('/recruiter-dashboard', { timeout: 10000 });
+  });
+
+  test('RECRUITER → /mentoring/new redirige a /recruiter-dashboard', async ({ page }) => {
+    await injectAuth(page, recruiterToken);
+    await page.goto('/mentoring/new');
+    await expect(page).toHaveURL('/recruiter-dashboard', { timeout: 10000 });
+  });
+
+  test('RECRUITER → /recruiter-dashboard está permitido', async ({ page }) => {
+    await injectAuth(page, recruiterToken);
+    await page.goto('/recruiter-dashboard');
+    await expect(page).toHaveURL('/recruiter-dashboard', { timeout: 15000 });
+  });
+
+  // ── DEV ────────────────────────────────────────────────────────────────────
+  // El landing de DEV es /home.
+
+  test('DEV → /admin redirige a /home', async ({ page }) => {
+    if (!devToken) {
+      test.skip();
+      return;
+    }
+    await injectAuth(page, devToken);
+    await page.goto('/admin');
+    await expect(page).toHaveURL('/home', { timeout: 10000 });
+  });
+
+  test('DEV → /recruiter-dashboard redirige a /home', async ({ page }) => {
+    if (!devToken) {
+      test.skip();
+      return;
+    }
+    await injectAuth(page, devToken);
+    await page.goto('/recruiter-dashboard');
+    await expect(page).toHaveURL('/home', { timeout: 10000 });
+  });
+
+  test('DEV → /mentoring/new redirige a /home', async ({ page }) => {
+    if (!devToken) {
+      test.skip();
+      return;
+    }
+    await injectAuth(page, devToken);
+    await page.goto('/mentoring/new');
+    await expect(page).toHaveURL('/home', { timeout: 10000 });
+  });
+
+  // ── MENTOR ─────────────────────────────────────────────────────────────────
+  // El landing de MENTOR es /dashboard.
+
+  test('MENTOR → /admin redirige a /dashboard', async ({ page }) => {
+    await injectAuth(page, mentorToken);
+    await page.goto('/admin');
+    await expect(page).toHaveURL('/dashboard', { timeout: 10000 });
+  });
+
+  test('MENTOR → /recruiter-dashboard redirige a /dashboard', async ({ page }) => {
+    await injectAuth(page, mentorToken);
+    await page.goto('/recruiter-dashboard');
+    await expect(page).toHaveURL('/dashboard', { timeout: 10000 });
+  });
+
+  test('MENTOR → /mentoring/new está permitido (no redirige)', async ({ page }) => {
+    await injectAuth(page, mentorToken);
+    await page.goto('/mentoring/new');
+    await expect(page).toHaveURL('/mentoring/new', { timeout: 15000 });
+  });
+
+  // ── ADMINISTRATOR ──────────────────────────────────────────────────────────
+  // ADMINISTRATOR puede acceder a todas las rutas rol-exclusivas.
+
+  test('ADMIN → /recruiter-dashboard está permitido', async ({ page }) => {
+    await injectAuth(page, adminToken);
+    await page.goto('/recruiter-dashboard');
+    await expect(page).toHaveURL('/recruiter-dashboard', { timeout: 15000 });
+  });
+
+  test('ADMIN → /admin está permitido', async ({ page }) => {
+    await injectAuth(page, adminToken);
+    await page.goto('/admin');
+    await expect(page).toHaveURL('/admin', { timeout: 15000 });
+  });
+
+  test('ADMIN → /dashboard está permitido', async ({ page }) => {
+    await injectAuth(page, adminToken);
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL('/dashboard', { timeout: 15000 });
+  });
+});

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -74,6 +74,12 @@ test.describe('Proyectos', () => {
     await nextBtn.click();
 
     // ---- Wizard paso 4: revisión y envío ----
+    // Esperar a que el panel de revisión esté renderizado y estable antes de
+    // clickear: durante la transición de paso el footer cambia de "Siguiente"
+    // a "Publicar Proyecto" y el botón se desprende del DOM si se clickea antes.
+    await expect(
+      page.getByRole('heading', { name: /revisa antes de publicar/i })
+    ).toBeVisible({ timeout: 10000 });
     await page.getByRole('button', { name: /publicar proyecto|crear proyecto|guardar/i }).click();
 
     // Después de crear, redirige al dashboard
@@ -111,7 +117,9 @@ test.describe('Proyectos', () => {
     await injectAuth(page, authToken);
     await page.goto(`/project/${projectSlug}`);
 
-    await expect(page.getByText(project.title)).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.getByRole('heading', { name: project.title })
+    ).toBeVisible({ timeout: 10000 });
   });
 
   test('should display empty state for user with no projects', async ({ page, request }) => {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -33,7 +33,9 @@ const getSectionTitle = (pathname: string): string => {
 };
 
 // Barra superior full-width (rediseño v2, SDD §12.3 R2).
-// OJO contrato E2E: un solo img[alt] dentro de <nav> (el avatar), el primer
+// OJO contrato E2E: el trigger del dropdown de usuario lleva
+// data-testid="user-menu-trigger" (el avatar puede ser <img> o el fallback de
+// inicial sin <img>, así que NO se debe targetear por img[alt]). El primer
 // <button> del nav debe ser la campana de notificaciones, y los textos
 // "Crear", "Panel", "Mi Perfil" y "Cerrar Sesión" no deben cambiar.
 const Navbar = ({ onToggleMenu, isMobileMenuOpen = false }: NavbarProps) => {
@@ -136,6 +138,7 @@ const Navbar = ({ onToggleMenu, isMobileMenuOpen = false }: NavbarProps) => {
         {/* Perfil del usuario / Dropdown */}
         <div className="relative" ref={dropdownRef}>
           <div
+            data-testid="user-menu-trigger"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
             className="flex items-center gap-2 cursor-pointer p-1.5 rounded-md transition-colors duration-200 text-text-main dark:text-text-light hover:bg-gray-100 dark:hover:bg-bg-hoverdark"
           >

--- a/src/router/RoleBasedRedirect.tsx
+++ b/src/router/RoleBasedRedirect.tsx
@@ -1,6 +1,7 @@
 import { Navigate } from "react-router-dom";
 import { useAuthZustand } from "../hooks/useAuthZustand";
 import Loading from "../components/ux/Loading";
+import { roleLandingPath } from "./roleLanding";
 
 const RoleBasedRedirect = () => {
   const { user, isAuthenticated, isLoading } = useAuthZustand();
@@ -18,16 +19,8 @@ const RoleBasedRedirect = () => {
     return <Navigate to="/login" replace />;
   }
 
-  // Redireccionar segun rol del usuario.
-  const roleToPathMap: { [key: string]: string } = {
-    DEV: "/home",
-    MENTOR: "/dashboard",
-    ADMINISTRATOR: "/admin",
-    RECRUITER: "/recruiter-dashboard",
-  };
-
-  // Si el rol no existe en nuestro mapa, lo mandamos al login por seguridad.
-  const path = user ? roleToPathMap[user.role] || "/login" : "/login";
+  // Redireccionar según rol del usuario (single source of truth en roleLanding.ts).
+  const path = user ? roleLandingPath(user.role) : "/login";
 
   // Usamos el componente Navigate de react-router-dom para hacer la redirección.
   return <Navigate to={path} replace />;

--- a/src/router/RoleProtectedRoute.tsx
+++ b/src/router/RoleProtectedRoute.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { useAuthZustand } from '../hooks/useAuthZustand';
+import Loading from '../components/ux/Loading';
+import { roleLandingPath } from './roleLanding';
+
+interface RoleProtectedRouteProps {
+  allowedRoles: string[];
+  children: React.ReactNode;
+}
+
+/**
+ * Guarda de ruta por rol. Si el usuario autenticado no tiene un rol incluido
+ * en allowedRoles, dispara un toast (dentro de useEffect, nunca durante el
+ * render) y redirige al landing propio del usuario para evitar bucles.
+ */
+const RoleProtectedRoute = ({ allowedRoles, children }: RoleProtectedRouteProps) => {
+  const { isAuthenticated, isLoading, user } = useAuthZustand();
+  const location = useLocation();
+  const toastFiredRef = useRef(false);
+
+  // Evaluar condición de acceso no autorizado solo cuando la auth ya está lista
+  const unauthorized = !isLoading && isAuthenticated && !!user && !allowedRoles.includes(user.role);
+
+  useEffect(() => {
+    if (unauthorized && !toastFiredRef.current) {
+      toastFiredRef.current = true;
+      toast.error('No autorizado');
+    }
+  }, [unauthorized]);
+
+  if (isLoading) {
+    return <Loading message="Verificando permisos" />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // Authenticated but user object not yet available — prevent silent bypass to children
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!allowedRoles.includes(user.role)) {
+    // El destino es siempre el landing propio del usuario → no puede generar bucle
+    return <Navigate to={roleLandingPath(user.role)} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default RoleProtectedRoute;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,6 +4,7 @@ import { Routes, Route, Navigate, useParams } from "react-router-dom";
 // Importamos nuestros componentes de ayuda para el enrutamiento
 import ProtectedRoute from "./ProtectedRoute";
 import RoleBasedRedirect from "./RoleBasedRedirect";
+import RoleProtectedRoute from "./RoleProtectedRoute";
 import PublicRoute from "./PublicRoute";
 import AuthenticatedLayout from "../components/layout/AuthenticatedLayout";
 import Loading from "../components/ux/Loading";
@@ -81,28 +82,121 @@ const AppRouter = () => {
             </ProtectedRoute>
           }
         >
-          <Route path="/dashboard" element={<DeveloperDashboard />} />
+          {/* DEV · MENTOR · ADMINISTRATOR */}
+          <Route
+            path="/dashboard"
+            element={
+              <RoleProtectedRoute allowedRoles={['DEV', 'MENTOR', 'ADMINISTRATOR']}>
+                <DeveloperDashboard />
+              </RoleProtectedRoute>
+            }
+          />
           {/* Fusión (F-16): el dashboard de mentor ahora es el unificado. */}
-          <Route path="/mentor-dashboard" element={<DeveloperDashboard />} />
-          <Route path="/admin" element={<AdminDashboard />} />
+          <Route
+            path="/mentor-dashboard"
+            element={
+              <RoleProtectedRoute allowedRoles={['DEV', 'MENTOR', 'ADMINISTRATOR']}>
+                <DeveloperDashboard />
+              </RoleProtectedRoute>
+            }
+          />
+
+          {/* ADMINISTRATOR solo */}
+          <Route
+            path="/admin"
+            element={
+              <RoleProtectedRoute allowedRoles={['ADMINISTRATOR']}>
+                <AdminDashboard />
+              </RoleProtectedRoute>
+            }
+          />
+
+          {/* Compartidas: cualquier usuario autenticado (sin restricción de rol) */}
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/settings" element={<EditProfilePage />} />
-          <Route path="/home" element={<HomePage />} />
-          <Route path="/projects/new" element={<CreateProjectPage />} />
-          <Route path="/projects/:slug/edit" element={<EditProjectPage />} />
+
+          {/* DEV · MENTOR · ADMINISTRATOR */}
+          <Route
+            path="/home"
+            element={
+              <RoleProtectedRoute allowedRoles={['DEV', 'MENTOR', 'ADMINISTRATOR']}>
+                <HomePage />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/projects/new"
+            element={
+              <RoleProtectedRoute allowedRoles={['DEV', 'MENTOR', 'ADMINISTRATOR']}>
+                <CreateProjectPage />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/projects/:slug/edit"
+            element={
+              <RoleProtectedRoute allowedRoles={['DEV', 'MENTOR', 'ADMINISTRATOR']}>
+                <EditProjectPage />
+              </RoleProtectedRoute>
+            }
+          />
+
+          {/* Compartidas */}
           <Route path="/project/:slug" element={<ProjectDetailPage />} />
           {/* Redirección legacy: notificaciones antiguas guardadas en la BD
               apuntan a /proyect/{slug} (typo corregido el 2026-06-12) */}
           <Route path="/proyect/:slug" element={<LegacyProjectRedirect />} />
-          <Route path="/mentoring" element={<MentoringListPage />} />
-          <Route path="/mentoring/new" element={<CreateMentorshipPage />} />
+
+          {/* DEV · MENTOR · ADMINISTRATOR */}
+          <Route
+            path="/mentoring"
+            element={
+              <RoleProtectedRoute allowedRoles={['DEV', 'MENTOR', 'ADMINISTRATOR']}>
+                <MentoringListPage />
+              </RoleProtectedRoute>
+            }
+          />
+
+          {/* MENTOR · ADMINISTRATOR (más específico antes que /mentoring/:slug) */}
+          <Route
+            path="/mentoring/new"
+            element={
+              <RoleProtectedRoute allowedRoles={['MENTOR', 'ADMINISTRATOR']}>
+                <CreateMentorshipPage />
+              </RoleProtectedRoute>
+            }
+          />
           <Route
             path="/mentoring/:slug/edit"
-            element={<EditMentorshipPage />}
+            element={
+              <RoleProtectedRoute allowedRoles={['MENTOR', 'ADMINISTRATOR']}>
+                <EditMentorshipPage />
+              </RoleProtectedRoute>
+            }
           />
-          <Route path="/mentoring/:slug" element={<MentoringDetailPage />} />
+
+          {/* DEV · MENTOR · ADMINISTRATOR */}
+          <Route
+            path="/mentoring/:slug"
+            element={
+              <RoleProtectedRoute allowedRoles={['DEV', 'MENTOR', 'ADMINISTRATOR']}>
+                <MentoringDetailPage />
+              </RoleProtectedRoute>
+            }
+          />
+
+          {/* Compartida */}
           <Route path="/jobs" element={<JobsListPage />} />
-          <Route path="/recruiter-dashboard" element={<RecruiterDashboard />} />
+
+          {/* RECRUITER · ADMINISTRATOR */}
+          <Route
+            path="/recruiter-dashboard"
+            element={
+              <RoleProtectedRoute allowedRoles={['RECRUITER', 'ADMINISTRATOR']}>
+                <RecruiterDashboard />
+              </RoleProtectedRoute>
+            }
+          />
         </Route>
 
         {/* RUTA PARA PÁGINAS NO ENCONTRADAS (404) */}

--- a/src/router/roleLanding.ts
+++ b/src/router/roleLanding.ts
@@ -1,0 +1,19 @@
+// Mapa centralizado: rol → ruta de inicio (single source of truth).
+// Consumido por RoleBasedRedirect.tsx y RoleProtectedRoute.tsx.
+export type Role = 'DEV' | 'MENTOR' | 'ADMINISTRATOR' | 'RECRUITER';
+
+const ROLE_LANDING_MAP: Record<Role, string> = {
+  DEV: '/home',
+  MENTOR: '/dashboard',
+  ADMINISTRATOR: '/admin',
+  RECRUITER: '/recruiter-dashboard',
+};
+
+/**
+ * Returns the landing path for the given role.
+ * Falls back to '/profile' for unknown/null roles — authenticated users must NOT
+ * be sent to /login because PublicRoute would bounce them back creating a loop.
+ */
+export function roleLandingPath(role: string): string {
+  return ROLE_LANDING_MAP[role?.toUpperCase() as Role] ?? '/profile';
+}


### PR DESCRIPTION
## Qué

P0 de seguridad: las rutas del frontend estaban protegidas solo por autenticación, así que un usuario con el rol equivocado podía montar páginas exclusivas de otro rol (shells vacíos). El backend ya devolvía 403 en los datos, pero la UI no redirigía.

## Cómo

- Nuevo `RoleProtectedRoute` con `allowedRoles`, aplicado vía una matriz ruta->rol en `router/index.tsx`.
- `roleLandingPath()` centralizado (single source of truth), reusado por `RoleBasedRedirect`.
- Acceso no autorizado -> toast "No autorizado" (una sola vez, vía `useRef`) + redirect al landing propio del usuario.
- Rol desconocido/undefined -> fallback a la ruta de perfil (compartida, no gateada) para evitar un loop de redirect contra `PublicRoute`.

## Matriz rol->ruta

| Ruta | DEV | MENTOR | ADMIN | RECRUITER |
|------|:--:|:--:|:--:|:--:|
| `/admin` | no | no | si | no |
| `/recruiter-dashboard` | no | no | si | si |
| `/dashboard`, `/mentor-dashboard`, `/home` | si | si | si | no |
| `/projects/new`, `/projects/:slug/edit` | si | si | si | no |
| `/mentoring`, `/mentoring/:slug` | si | si | si | no |
| `/mentoring/new`, `/mentoring/:slug/edit` | no | si | si | no |
| `/project/:slug`, perfil, settings, `/jobs` | si | si | si | si |

Sin cambios en el backend (ya estaba seguro con `@PreAuthorize`).

## Tests

Nuevo `e2e/authorization.spec.ts` (acceso cruzado denegado + acceso positivo por rol). Suite completa: **52 passed, 8 skipped, 0 failed**.

## Review

Pasó revisión adversarial (judgment-day): se corrigió un loop de redirect con rol desconocido y tests falso-verde (globs amplios + skip silencioso). Verificado post-fix.
