### PR TITLE
feat(admin): moderation drawer with 5-state report workflow (Slice 1b)

### DIFF
--- a/e2e/admin-moderation.spec.ts
+++ b/e2e/admin-moderation.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from '@playwright/test';
+import { apiRegisterAndLogin, apiLogin, apiCreateProject } from './helpers/api';
+import { injectAuth } from './helpers/auth';
+import { BASE_API_URL } from './helpers/constants';
+
+const PREFIX = 'mod';
+const RUN_ID = Date.now();
+
+let adminToken = '';
+let reportId = 0;
+let devAUsername = '';
+
+test.describe('Admin — Moderación de reportes', () => {
+  // El setup NO atrapa errores: si algo falla (Docker/DB caídos, contrato roto),
+  // el bloque entero falla de forma visible en vez de skippear silenciosamente.
+  test.beforeAll(async ({ request }) => {
+    // 1. Registrar y autenticar dev A (autor del contenido a reportar)
+    const devA = {
+      username: `${PREFIX}_a_${RUN_ID}`,
+      email: `${PREFIX}_a_${RUN_ID}@e2e.test`,
+      password: 'Password123!',
+      firstName: 'ModA',
+      lastName: 'Tester',
+    };
+    devAUsername = devA.username;
+    const devAToken = await apiRegisterAndLogin(request, devA).catch(async () =>
+      apiLogin(request, { username: devA.username, password: devA.password })
+    );
+
+    // 2. Dev A crea un proyecto publicado
+    const project = await apiCreateProject(request, devAToken, {
+      title: `${PREFIX} Proyecto Reportado ${RUN_ID}`,
+      subtitle: 'Proyecto para test de moderación E2E',
+      description: 'Este proyecto será reportado por otro usuario en el test E2E.',
+      status: 'published',
+    });
+
+    // 3. Registrar y autenticar dev B (quien hace el reporte)
+    const devB = {
+      username: `${PREFIX}_b_${RUN_ID}`,
+      email: `${PREFIX}_b_${RUN_ID}@e2e.test`,
+      password: 'Password123!',
+      firstName: 'ModB',
+      lastName: 'Reporter',
+    };
+    const devBToken = await apiRegisterAndLogin(request, devB).catch(async () =>
+      apiLogin(request, { username: devB.username, password: devB.password })
+    );
+
+    // 4. Dev B reporta el proyecto de dev A
+    const reportRes = await request.post(`${BASE_API_URL}/reports`, {
+      data: {
+        contentType: 'PROJECT',
+        contentId: project.id,
+        reason: 'SPAM',
+        description: 'E2E: reporte de moderación automatizado.',
+      },
+      headers: { Authorization: `Bearer ${devBToken}` },
+    });
+    if (!reportRes.ok())
+      throw new Error(`No se pudo crear el reporte de setup: ${reportRes.status()}`);
+
+    // 5. Login admin
+    adminToken = await apiLogin(request, {
+      username: 'admin',
+      password: 'Admin123!',
+    });
+
+    // 6. Buscar el reporte recién creado (autor único por RUN_ID) para obtener su ID
+    const reportsRes = await request.get(`${BASE_API_URL}/admin/reports`, {
+      params: { status: 'PENDING' },
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    if (!reportsRes.ok())
+      throw new Error(`No se pudo listar reportes PENDING: ${reportsRes.status()}`);
+
+    const reports = await reportsRes.json();
+    const ourReport = (reports as Array<{ id: number; contentAuthorUsername: string }>).find(
+      (r) => r.contentAuthorUsername === devAUsername
+    );
+    if (!ourReport)
+      throw new Error('El reporte creado en el setup no apareció en la cola PENDING.');
+    reportId = ourReport.id;
+  });
+
+  test('admin reclama y resuelve un reporte desde el drawer (UI + API)', async ({ page }) => {
+    await injectAuth(page, adminToken);
+    await page.goto('/admin');
+    await page.waitForURL('/admin', { timeout: 15000 });
+
+    // Ocultar el overlay de React Query Devtools (solo dev): flota sobre el footer
+    // del drawer e intercepta los clicks de los botones de acción.
+    await page.addStyleTag({
+      content: '.tsqd-parent-container { display: none !important; }',
+    });
+
+    await page.getByText('Reportes de contenido').waitFor({ timeout: 10000 });
+
+    // Abrir el drawer del reporte exacto creado en el setup
+    const reportCard = page.locator(`[data-report-id="${reportId}"]`);
+    await expect(reportCard).toBeVisible({ timeout: 10000 });
+    await reportCard.click();
+
+    const drawer = page.locator('[data-testid="report-detail-drawer"]');
+    await expect(drawer).toBeVisible({ timeout: 10000 });
+
+    // El badge de estado del header refleja el estado actual del reporte
+    const statusBadge = drawer.getByTestId('drawer-status-badge');
+
+    // --- Reclamar (PENDING → IN_REVIEW) --- (clicks scopeados al drawer)
+    await drawer.getByRole('button', { name: /reclamar/i }).click();
+    await expect(statusBadge).toHaveText('En revisión', { timeout: 15000 });
+
+    // --- Resolver (IN_REVIEW → RESOLVED) ---
+    await drawer.getByRole('button', { name: /resolver/i }).click();
+    // El form de nota inline aparece (nota opcional para resolve); confirmar sin nota
+    await drawer.getByRole('button', { name: /confirmar/i }).click();
+    await expect(statusBadge).toHaveText('Resuelto', { timeout: 15000 });
+
+    // El footer indica reporte cerrado
+    await expect(drawer.getByText(/cerrado/i)).toBeVisible({ timeout: 5000 });
+
+    // --- Verdad de fondo vía API: estado + audit trail ---
+    const detailRes = await page.request.get(
+      `${BASE_API_URL}/admin/reports/${reportId}`,
+      { headers: { Authorization: `Bearer ${adminToken}` } }
+    );
+    expect(detailRes.ok()).toBeTruthy();
+    const detail = await detailRes.json();
+    expect(detail.report.status).toBe('RESOLVED');
+    const actionTypes = (detail.auditTrail as Array<{ actionType: string }>).map(
+      (a) => a.actionType
+    );
+    expect(actionTypes).toContain('CLAIM');
+    expect(actionTypes).toContain('RESOLVE');
+
+    // Ya no aparece en la cola PENDING
+    const pendingRes = await page.request.get(`${BASE_API_URL}/admin/reports`, {
+      params: { status: 'PENDING' },
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    expect(pendingRes.ok()).toBeTruthy();
+    const pending = await pendingRes.json();
+    expect((pending as Array<{ id: number }>).some((r) => r.id === reportId)).toBeFalsy();
+  });
+});

--- a/src/api/reportApi.ts
+++ b/src/api/reportApi.ts
@@ -1,5 +1,5 @@
 import apiService from "./apiService";
-import type { AdminReport, CreateReportRequest, ReportStatus } from "../types";
+import type { AdminReport, CreateReportRequest, ReportDetail, ReportStatus } from "../types";
 
 /**
  * Reporta un contenido (proyecto, feedback o comentario).
@@ -24,7 +24,90 @@ export const fetchAdminReports = async (
 };
 
 /**
- * [ADMIN] Marca un reporte como revisado o descartado, con mensaje opcional.
+ * [ADMIN] Detalle enriquecido de un reporte:
+ * reporte base + historial de infracciones del autor + reportes similares + audit trail.
+ */
+export const fetchReportDetail = async (reportId: number): Promise<ReportDetail> => {
+  const { data } = await apiService.get<ReportDetail>(`/admin/reports/${reportId}`);
+  return data;
+};
+
+/**
+ * [ADMIN] Reclama un reporte PENDING → lo pasa a IN_REVIEW.
+ */
+export const claimReport = async (reportId: number): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(`/admin/reports/${reportId}/claim`);
+  return data;
+};
+
+/**
+ * [ADMIN] Resuelve un reporte (PENDING / IN_REVIEW / ESCALATED → RESOLVED).
+ */
+export const resolveReport = async (
+  reportId: number,
+  note?: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/resolve`,
+    note ? { note } : {}
+  );
+  return data;
+};
+
+/**
+ * [ADMIN] Rechaza un reporte → REJECTED.
+ */
+export const rejectReport = async (
+  reportId: number,
+  note?: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/reject`,
+    note ? { note } : {}
+  );
+  return data;
+};
+
+/**
+ * [ADMIN] Escala un reporte → ESCALATED.
+ */
+export const escalateReport = async (
+  reportId: number,
+  note?: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/escalate`,
+    note ? { note } : {}
+  );
+  return data;
+};
+
+/**
+ * [ADMIN] Envía una advertencia al autor del contenido reportado.
+ * La nota es OBLIGATORIA (el backend valida @NotBlank).
+ */
+export const warnContentOwner = async (
+  reportId: number,
+  note: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/warn`,
+    { note }
+  );
+  return data;
+};
+
+/**
+ * [ADMIN] Oculta el contenido reportado (soft-hide); marca como REVIEWED
+ * todos los reportes pendientes sobre ese contenido.
+ */
+export const hideReportedContent = async (reportId: number): Promise<void> => {
+  await apiService.patch(`/admin/reports/${reportId}/hide-content`);
+};
+
+/**
+ * [ADMIN] (Legacy) Marca un reporte como revisado o descartado, con mensaje opcional.
+ * @deprecated Usar las acciones específicas (resolveReport, rejectReport, etc.) en su lugar.
  */
 export const decideReport = async ({
   reportId,
@@ -40,14 +123,4 @@ export const decideReport = async ({
     { decision, adminMessage: adminMessage || undefined }
   );
   return data;
-};
-
-/**
- * [ADMIN] Oculta el contenido reportado (soft-hide); marca como REVIEWED
- * todos los reportes pendientes sobre ese contenido.
- */
-export const hideReportedContent = async (
-  reportId: number
-): Promise<void> => {
-  await apiService.patch(`/admin/reports/${reportId}/hide-content`);
 };

--- a/src/features/admin/components/ReportDetailDrawer.tsx
+++ b/src/features/admin/components/ReportDetailDrawer.tsx
@@ -1,0 +1,500 @@
+import { useEffect, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import toast from "react-hot-toast";
+import type { AxiosError } from "axios";
+import {
+  X,
+  ExternalLink,
+  Shield,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  AlertCircle,
+  EyeOff,
+} from "lucide-react";
+import {
+  fetchReportDetail,
+  claimReport,
+  resolveReport,
+  rejectReport,
+  escalateReport,
+  warnContentOwner,
+  hideReportedContent,
+} from "../../../api/reportApi";
+import {
+  REASON_LABELS,
+  CONTENT_TYPE_LABELS,
+  STATUS_LABELS,
+  STATUS_BADGE,
+  ACTION_TYPE_LABELS,
+} from "../../reports/reportLabels";
+import type { AdminReport, ReportDetail, ReportStatus } from "../../../types";
+
+interface ReportDetailDrawerProps {
+  reportId: number;
+  onClose: () => void;
+}
+
+type ActiveAction = "resolve" | "reject" | "escalate" | "warn" | null;
+
+const TERMINAL_STATUSES: ReportStatus[] = ["RESOLVED", "REJECTED"];
+const ACTIVE_STATUSES: ReportStatus[] = ["PENDING", "IN_REVIEW", "ESCALATED"];
+
+const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
+  const queryClient = useQueryClient();
+  const [activeAction, setActiveAction] = useState<ActiveAction>(null);
+  const [note, setNote] = useState("");
+
+  // Cerrar el drawer con la tecla Escape (a11y).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const {
+    data: detail,
+    isLoading,
+    error,
+  } = useQuery<ReportDetail>({
+    queryKey: ["reportDetail", reportId],
+    queryFn: () => fetchReportDetail(reportId),
+    staleTime: 1000 * 30,
+  });
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries({ queryKey: ["adminReports"] });
+    queryClient.invalidateQueries({ queryKey: ["reportDetail", reportId] });
+  };
+
+  const onActionSuccess = (updated: AdminReport) => {
+    invalidateAll();
+    setActiveAction(null);
+    setNote("");
+    toast.success(`Acción realizada. Estado: ${STATUS_LABELS[updated.status]}`);
+  };
+
+  const onActionError = (err: AxiosError<{ message?: string }>) => {
+    toast.error(
+      err.response?.data?.message || "No se pudo completar la acción."
+    );
+  };
+
+  const claimMutation = useMutation({
+    mutationFn: () => claimReport(reportId),
+    onSuccess: onActionSuccess,
+    onError: onActionError,
+  });
+
+  const resolveMutation = useMutation({
+    mutationFn: (n?: string) => resolveReport(reportId, n),
+    onSuccess: onActionSuccess,
+    onError: onActionError,
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: (n?: string) => rejectReport(reportId, n),
+    onSuccess: onActionSuccess,
+    onError: onActionError,
+  });
+
+  const escalateMutation = useMutation({
+    mutationFn: (n?: string) => escalateReport(reportId, n),
+    onSuccess: onActionSuccess,
+    onError: onActionError,
+  });
+
+  const warnMutation = useMutation({
+    mutationFn: (n: string) => warnContentOwner(reportId, n),
+    onSuccess: onActionSuccess,
+    onError: onActionError,
+  });
+
+  const hideMutation = useMutation({
+    mutationFn: () => hideReportedContent(reportId),
+    onSuccess: () => {
+      invalidateAll();
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      toast.success("Contenido ocultado. Los reportes pendientes quedaron resueltos.");
+    },
+    onError: onActionError,
+  });
+
+  const isBusy =
+    claimMutation.isPending ||
+    resolveMutation.isPending ||
+    rejectMutation.isPending ||
+    escalateMutation.isPending ||
+    warnMutation.isPending ||
+    hideMutation.isPending;
+
+  const handleConfirmAction = () => {
+    if (!activeAction) return;
+    if (activeAction === "warn") {
+      if (!note.trim()) {
+        toast.error("La nota es obligatoria para avisar al autor.");
+        return;
+      }
+      warnMutation.mutate(note.trim());
+    } else if (activeAction === "resolve") {
+      resolveMutation.mutate(note.trim() || undefined);
+    } else if (activeAction === "reject") {
+      rejectMutation.mutate(note.trim() || undefined);
+    } else if (activeAction === "escalate") {
+      escalateMutation.mutate(note.trim() || undefined);
+    }
+  };
+
+  const cancelAction = () => {
+    setActiveAction(null);
+    setNote("");
+  };
+
+  const report = detail?.report;
+  const currentStatus = report?.status;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-30 bg-black/30 backdrop-blur-[1px]"
+        onClick={onClose}
+      />
+
+      {/* Panel lateral */}
+      <div
+        data-testid="report-detail-drawer"
+        className="fixed top-0 right-0 h-full w-[520px] z-40 bg-white dark:bg-gray-900 shadow-2xl border-l border-gray-200 dark:border-gray-700 flex flex-col overflow-hidden"
+      >
+        {/* Cabecera */}
+        <div className="flex-shrink-0 px-5 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <h3 className="font-bold text-lg dark:text-text-light">
+              Reporte #{reportId}
+            </h3>
+            {report && (
+              <span
+                data-testid="drawer-status-badge"
+                className={`px-2 py-0.5 text-xs rounded-full font-medium ${STATUS_BADGE[report.status]}`}
+              >
+                {STATUS_LABELS[report.status]}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Cerrar panel"
+            className="p-1 rounded-md text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Cuerpo (con scroll) */}
+        <div className="flex-grow overflow-y-auto p-5 space-y-5">
+          {isLoading && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Cargando detalles...
+            </p>
+          )}
+          {error && (
+            <p className="text-sm text-red-500">
+              Error al cargar el detalle del reporte.
+            </p>
+          )}
+
+          {detail && report && (
+            <>
+              {/* Contenido reportado */}
+              <DrawerSection title="Contenido reportado">
+                <InfoRow label="Tipo" value={CONTENT_TYPE_LABELS[report.contentType]} />
+                <InfoRow label="Título">
+                  {report.contentLink ? (
+                    <Link
+                      to={report.contentLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                    >
+                      {report.contentLabel} <ExternalLink size={12} />
+                    </Link>
+                  ) : (
+                    <span className="text-sm dark:text-gray-300">
+                      {report.contentLabel}
+                    </span>
+                  )}
+                </InfoRow>
+                {report.contentAuthorUsername && (
+                  <InfoRow label="Autor" value={report.contentAuthorUsername} />
+                )}
+              </DrawerSection>
+
+              {/* Detalle del reporte */}
+              <DrawerSection title="Detalle del reporte">
+                <InfoRow label="Reportante" value={report.reporterUsername} />
+                <InfoRow label="Motivo" value={REASON_LABELS[report.reason]} />
+                <InfoRow label="Descripción">
+                  <p className="text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 rounded p-2 leading-relaxed">
+                    {report.description}
+                  </p>
+                </InfoRow>
+                <InfoRow
+                  label="Fecha"
+                  value={new Date(report.createdAt).toLocaleString("es-ES")}
+                />
+              </DrawerSection>
+
+              {/* Historial de infracciones del autor */}
+              {detail.infractionHistory.length > 0 && (
+                <DrawerSection
+                  title={`Historial de infracciones (${detail.infractionHistory.length})`}
+                >
+                  <div className="space-y-1">
+                    {detail.infractionHistory.map((r) => (
+                      <div
+                        key={r.id}
+                        className="flex items-center justify-between text-sm p-2 rounded bg-gray-50 dark:bg-gray-800"
+                      >
+                        <span className="text-gray-700 dark:text-gray-300 truncate mr-2">
+                          {r.contentLabel}
+                        </span>
+                        <span
+                          className={`shrink-0 px-2 py-0.5 text-xs rounded-full ${STATUS_BADGE[r.status]}`}
+                        >
+                          {STATUS_LABELS[r.status]}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </DrawerSection>
+              )}
+
+              {/* Reportes similares */}
+              {detail.similarReports.length > 0 && (
+                <DrawerSection
+                  title={`Reportes similares (${detail.similarReports.length})`}
+                >
+                  <div className="space-y-1">
+                    {detail.similarReports.map((r) => (
+                      <div
+                        key={r.id}
+                        className="flex items-center justify-between text-sm p-2 rounded bg-gray-50 dark:bg-gray-800"
+                      >
+                        <span className="text-gray-700 dark:text-gray-300 truncate mr-2">
+                          {r.contentLabel}
+                        </span>
+                        <span
+                          className={`shrink-0 px-2 py-0.5 text-xs rounded-full ${STATUS_BADGE[r.status]}`}
+                        >
+                          {STATUS_LABELS[r.status]}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </DrawerSection>
+              )}
+
+              {/* Audit trail */}
+              <DrawerSection title="Registro de acciones">
+                {detail.auditTrail.length === 0 ? (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Sin acciones registradas.
+                  </p>
+                ) : (
+                  <div className="space-y-2" data-testid="audit-trail">
+                    {detail.auditTrail.map((action) => (
+                      <div
+                        key={action.id}
+                        className="flex flex-col gap-0.5 p-2 rounded bg-gray-50 dark:bg-gray-800 text-sm"
+                        data-action-type={action.actionType}
+                      >
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-medium text-indigo-600 dark:text-cyan-400">
+                            {ACTION_TYPE_LABELS[action.actionType] ?? action.actionType}
+                          </span>
+                          <span className="text-gray-500 dark:text-gray-400">
+                            por {action.adminUsername}
+                          </span>
+                          <span className="ml-auto text-xs text-gray-400 shrink-0">
+                            {new Date(action.createdAt).toLocaleString("es-ES")}
+                          </span>
+                        </div>
+                        {action.note && (
+                          <p className="text-xs text-gray-600 dark:text-gray-300 pl-2 border-l-2 border-indigo-300 dark:border-cyan-700 mt-1">
+                            {action.note}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </DrawerSection>
+
+              {/* Último mensaje al usuario (si existe) */}
+              {report.adminMessage && (
+                <DrawerSection title="Último mensaje al usuario">
+                  <p className="text-sm text-indigo-700 dark:text-cyan-400 bg-indigo-50 dark:bg-cyan-900/20 rounded p-2">
+                    {report.adminMessage}
+                  </p>
+                </DrawerSection>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Footer con acciones */}
+        {report && (
+          <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 p-4 space-y-3">
+            {TERMINAL_STATUSES.includes(currentStatus!) ? (
+              <p className="text-sm text-center text-gray-500 dark:text-gray-400">
+                Este reporte está cerrado ({STATUS_LABELS[currentStatus!]}).
+              </p>
+            ) : (
+              <>
+                {/* Formulario de nota inline (aparece al seleccionar acción) */}
+                {activeAction && (
+                  <div className="space-y-2">
+                    <label className="block text-sm font-medium dark:text-gray-300">
+                      {activeAction === "warn" ? (
+                        <>
+                          Nota para el autor{" "}
+                          <span className="text-red-500">*</span>
+                        </>
+                      ) : (
+                        "Nota (opcional)"
+                      )}
+                    </label>
+                    <textarea
+                      value={note}
+                      onChange={(e) => setNote(e.target.value)}
+                      rows={2}
+                      maxLength={500}
+                      placeholder={
+                        activeAction === "warn"
+                          ? "Explica la advertencia al autor (requerido)..."
+                          : "Motivo de la acción (opcional)..."
+                      }
+                      className="w-full rounded-md bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-400 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 dark:focus:border-cyan-500 resize-none"
+                    />
+                    <div className="flex gap-2 justify-end">
+                      <button
+                        onClick={cancelAction}
+                        className="px-3 py-1.5 text-xs rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                      >
+                        Cancelar
+                      </button>
+                      <button
+                        onClick={handleConfirmAction}
+                        disabled={
+                          isBusy ||
+                          (activeAction === "warn" && !note.trim())
+                        }
+                        className="px-3 py-1.5 text-xs rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                      >
+                        {isBusy ? "Procesando..." : "Confirmar"}
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Botones de acción (se ocultan cuando hay un activeAction) */}
+                {!activeAction && (
+                  <div className="flex flex-wrap gap-2">
+                    {currentStatus === "PENDING" && (
+                      <button
+                        onClick={() => claimMutation.mutate()}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                      >
+                        <Shield size={12} /> Reclamar
+                      </button>
+                    )}
+
+                    {ACTIVE_STATUSES.includes(currentStatus!) && (
+                      <>
+                        <button
+                          onClick={() => setActiveAction("resolve")}
+                          disabled={isBusy}
+                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+                        >
+                          <CheckCircle size={12} /> Resolver
+                        </button>
+                        <button
+                          onClick={() => setActiveAction("reject")}
+                          disabled={isBusy}
+                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-gray-600 text-white hover:bg-gray-700 disabled:opacity-50 transition-colors"
+                        >
+                          <XCircle size={12} /> Rechazar
+                        </button>
+                        <button
+                          onClick={() => setActiveAction("escalate")}
+                          disabled={isBusy}
+                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50 transition-colors"
+                        >
+                          <AlertTriangle size={12} /> Escalar
+                        </button>
+                        <button
+                          onClick={() => setActiveAction("warn")}
+                          disabled={isBusy}
+                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-yellow-600 text-white hover:bg-yellow-700 disabled:opacity-50 transition-colors"
+                        >
+                          <AlertCircle size={12} /> Avisar al autor
+                        </button>
+                        <button
+                          onClick={() => hideMutation.mutate()}
+                          disabled={isBusy}
+                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+                        >
+                          <EyeOff size={12} /> Ocultar contenido
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+/* ---------- Componentes auxiliares locales ---------- */
+
+const DrawerSection = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <div className="space-y-2">
+    <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+      {title}
+    </h4>
+    {children}
+  </div>
+);
+
+const InfoRow = ({
+  label,
+  value,
+  children,
+}: {
+  label: string;
+  value?: string;
+  children?: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-0.5">
+    <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
+    {children ?? (
+      <span className="text-sm font-medium dark:text-gray-200">{value}</span>
+    )}
+  </div>
+);
+
+export default ReportDetailDrawer;

--- a/src/features/admin/components/ReportsPanel.tsx
+++ b/src/features/admin/components/ReportsPanel.tsx
@@ -1,44 +1,28 @@
 import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
-import toast from "react-hot-toast";
-import type { AxiosError } from "axios";
-import { Check, EyeOff, ExternalLink, Flag, MessageSquare, X } from "lucide-react";
-import {
-  fetchAdminReports,
-  decideReport,
-  hideReportedContent,
-} from "../../../api/reportApi";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Flag } from "lucide-react";
+import { fetchAdminReports } from "../../../api/reportApi";
 import {
   REASON_LABELS,
   CONTENT_TYPE_LABELS,
+  STATUS_LABELS,
+  STATUS_BADGE,
 } from "../../reports/reportLabels";
 import type { AdminReport, ReportStatus } from "../../../types";
-import ReportActionModal from "./ReportActionModal";
+import ReportDetailDrawer from "./ReportDetailDrawer";
 
-type TabStatus = ReportStatus;
-
-type PendingAction =
-  | { type: "review" | "dismiss"; report: AdminReport }
-  | { type: "hide"; report: AdminReport }
-  | null;
-
-const STATUS_TABS: { label: string; value: TabStatus }[] = [
+const STATUS_TABS: { label: string; value: ReportStatus }[] = [
   { label: "Pendientes", value: "PENDING" },
-  { label: "Revisados", value: "REVIEWED" },
-  { label: "Descartados", value: "DISMISSED" },
+  { label: "En revisión", value: "IN_REVIEW" },
+  { label: "Resueltos", value: "RESOLVED" },
+  { label: "Rechazados", value: "REJECTED" },
+  { label: "Escalados", value: "ESCALATED" },
 ];
-
-const STATUS_BADGE: Record<TabStatus, string> = {
-  PENDING: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300",
-  REVIEWED: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
-  DISMISSED: "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
-};
 
 const ReportsPanel = () => {
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<TabStatus>("PENDING");
-  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [activeTab, setActiveTab] = useState<ReportStatus>("PENDING");
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
 
   const { data: reports, isLoading } = useQuery<AdminReport[]>({
     queryKey: ["adminReports", activeTab],
@@ -46,58 +30,16 @@ const ReportsPanel = () => {
     staleTime: 1000 * 60,
   });
 
-  const invalidate = () =>
-    queryClient.invalidateQueries({ queryKey: ["adminReports"] });
-
-  const onError = (error: AxiosError<{ message?: string }>) => {
-    toast.error(error.response?.data?.message || "No se pudo completar la acción.");
+  const handleTabChange = (status: ReportStatus) => {
+    setActiveTab(status);
+    setSelectedReportId(null);
   };
 
-  const decideMutation = useMutation({
-    mutationFn: decideReport,
-    onSuccess: (data) => {
-      invalidate();
-      toast.success(
-        data.status === "DISMISSED" ? "Reporte descartado." : "Reporte marcado como revisado."
-      );
-      setPendingAction(null);
-    },
-    onError,
-  });
-
-  const hideMutation = useMutation({
-    mutationFn: hideReportedContent,
-    onSuccess: () => {
-      invalidate();
-      queryClient.invalidateQueries({ queryKey: ["projects"] });
-      toast.success("Contenido ocultado. Los reportes pendientes quedaron resueltos.");
-      setPendingAction(null);
-    },
-    onError,
-  });
-
-  const isBusy = decideMutation.isPending || hideMutation.isPending;
-
-  const handleModalConfirm = (adminMessage: string) => {
-    if (!pendingAction) return;
-    if (pendingAction.type === "hide") {
-      hideMutation.mutate(pendingAction.report.id);
-    } else {
-      decideMutation.mutate({
-        reportId: pendingAction.report.id,
-        decision: pendingAction.type,
-        adminMessage: adminMessage.trim() || undefined,
-      });
-    }
+  const handleCloseDrawer = () => {
+    setSelectedReportId(null);
+    // Refrescar la pestaña activa para reflejar cambios de estado
+    queryClient.invalidateQueries({ queryKey: ["adminReports", activeTab] });
   };
-
-  const modalConfig = pendingAction
-    ? pendingAction.type === "review"
-      ? { title: "Marcar como revisado", confirmLabel: "Confirmar revisión", confirmClass: "bg-emerald-600 hover:bg-emerald-700" }
-      : pendingAction.type === "dismiss"
-      ? { title: "Descartar reporte", confirmLabel: "Descartar", confirmClass: "bg-gray-500 hover:bg-gray-600" }
-      : { title: "Ocultar contenido", confirmLabel: "Ocultar contenido", confirmClass: "bg-red-600 hover:bg-red-700" }
-    : null;
 
   return (
     <section className="space-y-4">
@@ -105,23 +47,29 @@ const ReportsPanel = () => {
         <Flag size={20} /> Reportes de contenido
       </h2>
 
-      {/* Tabs */}
-      <div className="flex gap-1 border-b border-gray-300 dark:border-gray-700">
+      {/* Tabs de estado */}
+      <div className="flex gap-1 border-b border-gray-300 dark:border-gray-700 overflow-x-auto">
         {STATUS_TABS.map((tab) => (
           <button
             key={tab.value}
-            onClick={() => setActiveTab(tab.value)}
-            className={`px-4 py-2 text-sm font-medium rounded-t-md transition-colors ${
+            onClick={() => handleTabChange(tab.value)}
+            className={`px-3 py-2 text-sm font-medium rounded-t-md transition-colors whitespace-nowrap ${
               activeTab === tab.value
                 ? "bg-white dark:bg-bg-dark text-indigo-600 dark:text-cyan-400 border border-b-0 border-gray-300 dark:border-gray-700"
                 : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
             }`}
           >
             {tab.label}
+            {activeTab === tab.value && reports && reports.length > 0 && (
+              <span className="ml-1.5 px-1.5 py-0.5 text-xs rounded-full bg-indigo-100 text-indigo-700 dark:bg-cyan-900/40 dark:text-cyan-300">
+                {reports.length}
+              </span>
+            )}
           </button>
         ))}
       </div>
 
+      {/* Lista de triage */}
       {isLoading ? (
         <p className="p-4 text-gray-500 dark:text-gray-400">Cargando reportes...</p>
       ) : !reports || reports.length === 0 ? (
@@ -129,97 +77,63 @@ const ReportsPanel = () => {
           No hay reportes en esta categoría.
         </p>
       ) : (
-        reports.map((report) => (
-          <div
-            key={report.id}
-            className="p-4 bg-white dark:bg-bg-dark rounded-lg shadow border border-divider dark:border-gray-700 space-y-2"
-          >
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="px-2 py-0.5 text-xs rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 font-medium">
-                {REASON_LABELS[report.reason]}
-              </span>
-              <span className="px-2 py-0.5 text-xs rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
-                {CONTENT_TYPE_LABELS[report.contentType]}
-              </span>
-              <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${STATUS_BADGE[report.status]}`}>
-                {report.status === "PENDING" ? "Pendiente" : report.status === "REVIEWED" ? "Revisado" : "Descartado"}
-              </span>
-              <span className="text-xs text-gray-500 ml-auto">
-                {new Date(report.createdAt).toLocaleDateString("es-ES")}
-              </span>
-            </div>
-
-            <p className="text-sm dark:text-text-light">
-              <span className="font-semibold">{report.reporterUsername}</span>{" "}
-              reportó{" "}
-              <span className="font-medium">"{report.contentLabel}"</span>
-              {report.contentAuthorUsername && (
-                <span className="text-gray-500 dark:text-gray-400">
-                  {" "}de {report.contentAuthorUsername}
+        <div className="space-y-2">
+          {reports.map((report) => (
+            <button
+              key={report.id}
+              data-report-id={report.id}
+              onClick={() => setSelectedReportId(report.id)}
+              className={`w-full text-left p-4 bg-white dark:bg-bg-dark rounded-lg shadow border transition-colors cursor-pointer ${
+                selectedReportId === report.id
+                  ? "border-indigo-500 dark:border-cyan-500 ring-2 ring-indigo-200 dark:ring-cyan-900/50"
+                  : "border-divider dark:border-gray-700 hover:border-indigo-300 dark:hover:border-gray-500"
+              }`}
+            >
+              {/* Badges de estado y tipo */}
+              <div className="flex flex-wrap items-center gap-2 mb-2">
+                <span className="px-2 py-0.5 text-xs rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 font-medium">
+                  {REASON_LABELS[report.reason]}
                 </span>
-              )}
-            </p>
-
-            <p className="text-sm text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/60 rounded p-2">
-              {report.description}
-            </p>
-
-            {report.adminMessage && (
-              <p className="text-sm text-indigo-700 dark:text-cyan-400 bg-indigo-50 dark:bg-cyan-900/20 rounded p-2 flex items-start gap-2">
-                <MessageSquare size={14} className="mt-0.5 shrink-0" />
-                <span>{report.adminMessage}</span>
-              </p>
-            )}
-
-            <div className="flex flex-wrap items-center gap-3 pt-1">
-              {report.contentLink && (
-                <Link
-                  to={report.contentLink}
-                  className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                <span className="px-2 py-0.5 text-xs rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                  {CONTENT_TYPE_LABELS[report.contentType]}
+                </span>
+                <span
+                  className={`px-2 py-0.5 text-xs rounded-full font-medium ${STATUS_BADGE[report.status]}`}
                 >
-                  <ExternalLink size={12} /> Ver contenido
-                </Link>
-              )}
+                  {STATUS_LABELS[report.status]}
+                </span>
+                <span className="text-xs text-gray-500 ml-auto">
+                  {new Date(report.createdAt).toLocaleDateString("es-ES")}
+                </span>
+              </div>
 
-              {activeTab === "PENDING" && (
-                <div className="flex gap-2 ml-auto">
-                  <button
-                    onClick={() => setPendingAction({ type: "review", report })}
-                    disabled={isBusy}
-                    className="inline-flex items-center gap-1 px-3 py-1 text-xs rounded-md bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
-                  >
-                    <Check size={12} /> Revisado
-                  </button>
-                  <button
-                    onClick={() => setPendingAction({ type: "dismiss", report })}
-                    disabled={isBusy}
-                    className="inline-flex items-center gap-1 px-3 py-1 text-xs rounded-md bg-gray-500 text-white hover:bg-gray-600 disabled:opacity-50"
-                  >
-                    <X size={12} /> Descartar
-                  </button>
-                  <button
-                    onClick={() => setPendingAction({ type: "hide", report })}
-                    disabled={isBusy}
-                    className="inline-flex items-center gap-1 px-3 py-1 text-xs rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
-                  >
-                    <EyeOff size={12} /> Ocultar contenido
-                  </button>
-                </div>
+              {/* Descripción resumida */}
+              <p className="text-sm dark:text-text-light">
+                <span className="font-semibold">{report.reporterUsername}</span>{" "}
+                reportó{" "}
+                <span className="font-medium">"{report.contentLabel}"</span>
+                {report.contentAuthorUsername && (
+                  <span className="text-gray-500 dark:text-gray-400">
+                    {" "}de {report.contentAuthorUsername}
+                  </span>
+                )}
+              </p>
+
+              {report.description && (
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate">
+                  {report.description}
+                </p>
               )}
-            </div>
-          </div>
-        ))
+            </button>
+          ))}
+        </div>
       )}
 
-      {pendingAction && modalConfig && (
-        <ReportActionModal
-          isOpen
-          onClose={() => setPendingAction(null)}
-          onConfirm={handleModalConfirm}
-          title={modalConfig.title}
-          confirmLabel={modalConfig.confirmLabel}
-          confirmClass={modalConfig.confirmClass}
-          isPending={isBusy}
+      {/* Drawer de detalle (overlay fijo) */}
+      {selectedReportId !== null && (
+        <ReportDetailDrawer
+          reportId={selectedReportId}
+          onClose={handleCloseDrawer}
         />
       )}
     </section>

--- a/src/features/reports/reportLabels.ts
+++ b/src/features/reports/reportLabels.ts
@@ -1,4 +1,4 @@
-import type { ReportContentType, ReportReason } from "../../types";
+import type { ReportContentType, ReportReason, ReportStatus } from "../../types";
 
 /** Etiquetas en español de los motivos de reporte (espejo del enum del back). */
 export const REASON_LABELS: Record<ReportReason, string> = {
@@ -14,4 +14,40 @@ export const CONTENT_TYPE_LABELS: Record<ReportContentType, string> = {
   FEEDBACK: "Feedback",
   FEEDBACK_COMMENT: "Comentario",
   KUDO_COMMENT: "Comentario de kudo",
+};
+
+/** Etiquetas en español de los cinco estados de un reporte. */
+export const STATUS_LABELS: Record<ReportStatus, string> = {
+  PENDING: "Pendiente",
+  IN_REVIEW: "En revisión",
+  RESOLVED: "Resuelto",
+  REJECTED: "Rechazado",
+  ESCALATED: "Escalado",
+};
+
+/** Clases Tailwind para el badge de estado en modo claro y oscuro. */
+export const STATUS_BADGE: Record<ReportStatus, string> = {
+  PENDING:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300",
+  IN_REVIEW:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  RESOLVED:
+    "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
+  REJECTED:
+    "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+  ESCALATED:
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300",
+};
+
+/**
+ * Etiquetas en español de los tipos de acción de moderación
+ * (mirrors de ModerationActionType del back).
+ */
+export const ACTION_TYPE_LABELS: Record<string, string> = {
+  CLAIM: "Reclamado",
+  RESOLVE: "Resuelto",
+  REJECT: "Rechazado",
+  ESCALATE: "Escalado",
+  WARN: "Advertencia al autor",
+  HIDE_CONTENT: "Contenido ocultado",
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -241,7 +241,12 @@ export interface CreateReportRequest {
   description: string;
 }
 
-export type ReportStatus = "PENDING" | "REVIEWED" | "DISMISSED";
+export type ReportStatus =
+  | "PENDING"
+  | "IN_REVIEW"
+  | "RESOLVED"
+  | "REJECTED"
+  | "ESCALATED";
 
 /** Vista admin de un reporte, con el contenido resuelto por el backend. */
 export interface AdminReport {
@@ -257,6 +262,23 @@ export interface AdminReport {
   contentLink: string | null;
   contentAuthorUsername: string | null;
   adminMessage?: string | null;
+}
+
+/** Entrada del registro de moderación (audit trail). */
+export interface ModerationAction {
+  id: number;
+  actionType: string;
+  adminUsername: string;
+  note?: string | null;
+  createdAt: string;
+}
+
+/** Detalle enriquecido de un reporte: reporte + historial + similares + audit trail. */
+export interface ReportDetail {
+  report: AdminReport;
+  infractionHistory: AdminReport[];
+  similarReports: AdminReport[];
+  auditTrail: ModerationAction[];
 }
 
 /*===================================================


### PR DESCRIPTION
## Qué

Slice 1b del rediseño de moderación (P1): la UI de admin que consume la API del Slice 1a (backend, ya en `main`).

## Cómo

- **Panel** con 5 tabs de estado: Pendientes / En revisión / Resueltos / Rechazados / Escalados.
- Seleccionar un reporte abre un **drawer lateral** con la vista enriquecida:
  - Contenido reportado, creador, reportante y motivo.
  - **Historial de infracciones** del autor.
  - **Reportes similares** activos.
  - **Registro de acciones** (audit trail) completo.
- **Acciones gateadas por estado**, espejando la máquina de estados del backend: reclamar (solo PENDING); resolver/rechazar/escalar/avisar/ocultar en estados activos; terminales muestran mensaje de cerrado. Avisar exige nota no vacía.
- a11y: el drawer cierra con Escape, botón y backdrop.

## Tests

Nuevo `e2e/admin-moderation.spec.ts`: maneja claim -> resolve por el drawer y verifica estado + audit trail vía API. Verificado contra el backend real. Suite completa: **53 passed, 8 skipped, 0 failed** (estable en repeticiones).

## Notas

- `size:exception` acordado (feature cohesiva drawer+panel, ~870 líneas).
- Depende del backend Slice 1a (mergeado en `main`, corriendo).
