### PR TITLE
feat(admin): restrict-author action in the moderation drawer (Slice 3b)

### DIFF
--- a/e2e/admin-restriction.spec.ts
+++ b/e2e/admin-restriction.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+import { apiRegisterAndLogin, apiLogin, apiCreateProject } from './helpers/api';
+import { injectAuth } from './helpers/auth';
+import { BASE_API_URL } from './helpers/constants';
+
+const PREFIX = 'restr';
+const RUN_ID = Date.now();
+
+let adminToken = '';
+let devAToken = '';
+let reportId = 0;
+let devAUsername = '';
+
+test.describe('Admin — Restricción temporal de cuenta', () => {
+  // Setup sin try-catch: si algo falla, el bloque falla de forma visible.
+  test.beforeAll(async ({ request }) => {
+    // Dev A: autor del contenido reportado (será restringido)
+    const devA = {
+      username: `${PREFIX}_a_${RUN_ID}`,
+      email: `${PREFIX}_a_${RUN_ID}@e2e.test`,
+      password: 'Password123!',
+      firstName: 'RestrA',
+      lastName: 'Autor',
+    };
+    devAUsername = devA.username;
+    devAToken = await apiRegisterAndLogin(request, devA).catch(async () =>
+      apiLogin(request, { username: devA.username, password: devA.password })
+    );
+
+    await apiCreateProject(request, devAToken, {
+      title: `${PREFIX} Proyecto ${RUN_ID}`,
+      subtitle: 'Proyecto para test de restricción E2E',
+      description: 'Este proyecto será reportado y su autor restringido.',
+      status: 'published',
+    });
+
+    // El proyecto reportable: usamos otro proyecto de A como objetivo del reporte
+    const target = await apiCreateProject(request, devAToken, {
+      title: `${PREFIX} Objetivo ${RUN_ID}`,
+      subtitle: 'Objetivo del reporte',
+      description: 'Contenido reportado por dev B.',
+      status: 'published',
+    });
+
+    // Dev B: reporta el proyecto de A
+    const devB = {
+      username: `${PREFIX}_b_${RUN_ID}`,
+      email: `${PREFIX}_b_${RUN_ID}@e2e.test`,
+      password: 'Password123!',
+      firstName: 'RestrB',
+      lastName: 'Reporter',
+    };
+    const devBToken = await apiRegisterAndLogin(request, devB).catch(async () =>
+      apiLogin(request, { username: devB.username, password: devB.password })
+    );
+
+    const reportRes = await request.post(`${BASE_API_URL}/reports`, {
+      data: {
+        contentType: 'PROJECT',
+        contentId: target.id,
+        reason: 'SPAM',
+        description: 'E2E: reporte para test de restricción.',
+      },
+      headers: { Authorization: `Bearer ${devBToken}` },
+    });
+    if (!reportRes.ok())
+      throw new Error(`No se pudo crear el reporte de setup: ${reportRes.status()}`);
+
+    adminToken = await apiLogin(request, { username: 'admin', password: 'Admin123!' });
+
+    const reportsRes = await request.get(`${BASE_API_URL}/admin/reports`, {
+      params: { status: 'PENDING' },
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    if (!reportsRes.ok())
+      throw new Error(`No se pudo listar reportes PENDING: ${reportsRes.status()}`);
+    const reports = await reportsRes.json();
+    const ourReport = (reports as Array<{ id: number; contentAuthorUsername: string }>).find(
+      (r) => r.contentAuthorUsername === devAUsername
+    );
+    if (!ourReport)
+      throw new Error('El reporte creado en el setup no apareció en la cola PENDING.');
+    reportId = ourReport.id;
+  });
+
+  test('admin restringe al autor desde el drawer y el enforcement lo bloquea', async ({ page }) => {
+    await injectAuth(page, adminToken);
+    await page.goto('/admin');
+    await page.waitForURL('/admin', { timeout: 15000 });
+
+    // Ocultar el overlay de React Query Devtools (solo dev) que intercepta clicks.
+    await page.addStyleTag({
+      content: '.tsqd-parent-container { display: none !important; }',
+    });
+
+    await page.getByText('Reportes de contenido').waitFor({ timeout: 10000 });
+
+    const reportCard = page.locator(`[data-report-id="${reportId}"]`);
+    await expect(reportCard).toBeVisible({ timeout: 10000 });
+    await reportCard.click();
+
+    const drawer = page.locator('[data-testid="report-detail-drawer"]');
+    await expect(drawer).toBeVisible({ timeout: 10000 });
+
+    // Abrir el formulario de restricción, elegir preset de 7 días y confirmar
+    await drawer.getByRole('button', { name: /restringir autor/i }).click();
+    await drawer.getByRole('button', { name: '7 días' }).click();
+    await drawer.getByRole('button', { name: /confirmar/i }).click();
+
+    // El audit trail debe registrar la acción RESTRICT (verdad vía API)
+    await expect(async () => {
+      const detailRes = await page.request.get(
+        `${BASE_API_URL}/admin/reports/${reportId}`,
+        { headers: { Authorization: `Bearer ${adminToken}` } }
+      );
+      expect(detailRes.ok()).toBeTruthy();
+      const detail = await detailRes.json();
+      const types = (detail.auditTrail as Array<{ actionType: string }>).map((a) => a.actionType);
+      expect(types).toContain('RESTRICT');
+    }).toPass({ timeout: 15000 });
+
+    // Enforcement real: el autor restringido no puede publicar un proyecto → 403.
+    // Se usa apiCreateProject porque manda el body válido completo (incl.
+    // technologyIds); el guard de restricción vive en el service, DESPUÉS de la
+    // validación del controller, así que un body inválido daría 400 y no probaría
+    // el enforcement. El helper lanza un Error con el status en el mensaje.
+    await expect(
+      apiCreateProject(page.request, devAToken, {
+        title: `${PREFIX} Bloqueado ${RUN_ID}`,
+        subtitle: 'No debería crearse',
+        description: 'El autor está restringido y no puede publicar.',
+        status: 'published',
+      })
+    ).rejects.toThrow(/403/);
+  });
+});

--- a/src/api/reportApi.ts
+++ b/src/api/reportApi.ts
@@ -98,6 +98,23 @@ export const warnContentOwner = async (
 };
 
 /**
+ * [ADMIN] Restringe temporalmente al autor del contenido reportado:
+ * no podrá comentar ni publicar hasta que venza la restricción.
+ * Duración en horas (presets: 24 / 168 / 720). El backend valida durationHours >= 1.
+ */
+export const restrictUser = async (
+  reportId: number,
+  durationHours: number,
+  note?: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/restrict`,
+    note ? { durationHours, note } : { durationHours }
+  );
+  return data;
+};
+
+/**
  * [ADMIN] Oculta el contenido reportado (soft-hide); marca como REVIEWED
  * todos los reportes pendientes sobre ese contenido.
  */

--- a/src/features/admin/components/ReportDetailDrawer.tsx
+++ b/src/features/admin/components/ReportDetailDrawer.tsx
@@ -12,6 +12,7 @@ import {
   AlertTriangle,
   AlertCircle,
   EyeOff,
+  Ban,
 } from "lucide-react";
 import {
   fetchReportDetail,
@@ -20,6 +21,7 @@ import {
   rejectReport,
   escalateReport,
   warnContentOwner,
+  restrictUser,
   hideReportedContent,
 } from "../../../api/reportApi";
 import {
@@ -36,15 +38,25 @@ interface ReportDetailDrawerProps {
   onClose: () => void;
 }
 
-type ActiveAction = "resolve" | "reject" | "escalate" | "warn" | null;
+type ActiveAction = "resolve" | "reject" | "escalate" | "warn" | "restrict" | null;
 
 const TERMINAL_STATUSES: ReportStatus[] = ["RESOLVED", "REJECTED"];
 const ACTIVE_STATUSES: ReportStatus[] = ["PENDING", "IN_REVIEW", "ESCALATED"];
+
+/** Presets de duración de restricción (en horas). */
+const RESTRICTION_PRESETS: { label: string; hours: number }[] = [
+  { label: "24 horas", hours: 24 },
+  { label: "7 días", hours: 168 },
+  { label: "30 días", hours: 720 },
+];
 
 const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
   const queryClient = useQueryClient();
   const [activeAction, setActiveAction] = useState<ActiveAction>(null);
   const [note, setNote] = useState("");
+  const [restrictHours, setRestrictHours] = useState<number>(
+    RESTRICTION_PRESETS[0].hours
+  );
 
   // Cerrar el drawer con la tecla Escape (a11y).
   useEffect(() => {
@@ -113,6 +125,18 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
     onError: onActionError,
   });
 
+  const restrictMutation = useMutation({
+    mutationFn: ({ hours, n }: { hours: number; n?: string }) =>
+      restrictUser(reportId, hours, n),
+    onSuccess: () => {
+      invalidateAll();
+      setActiveAction(null);
+      setNote("");
+      toast.success("Autor restringido temporalmente.");
+    },
+    onError: onActionError,
+  });
+
   const hideMutation = useMutation({
     mutationFn: () => hideReportedContent(reportId),
     onSuccess: () => {
@@ -129,6 +153,7 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
     rejectMutation.isPending ||
     escalateMutation.isPending ||
     warnMutation.isPending ||
+    restrictMutation.isPending ||
     hideMutation.isPending;
 
   const handleConfirmAction = () => {
@@ -139,6 +164,8 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
         return;
       }
       warnMutation.mutate(note.trim());
+    } else if (activeAction === "restrict") {
+      restrictMutation.mutate({ hours: restrictHours, n: note.trim() || undefined });
     } else if (activeAction === "resolve") {
       resolveMutation.mutate(note.trim() || undefined);
     } else if (activeAction === "reject") {
@@ -151,6 +178,7 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
   const cancelAction = () => {
     setActiveAction(null);
     setNote("");
+    setRestrictHours(RESTRICTION_PRESETS[0].hours);
   };
 
   const report = detail?.report;
@@ -357,6 +385,29 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
                 {/* Formulario de nota inline (aparece al seleccionar acción) */}
                 {activeAction && (
                   <div className="space-y-2">
+                    {activeAction === "restrict" && (
+                      <div className="space-y-1.5">
+                        <span className="block text-sm font-medium dark:text-gray-300">
+                          Duración de la restricción
+                        </span>
+                        <div className="flex gap-2" data-testid="restrict-presets">
+                          {RESTRICTION_PRESETS.map((preset) => (
+                            <button
+                              key={preset.hours}
+                              type="button"
+                              onClick={() => setRestrictHours(preset.hours)}
+                              className={`flex-1 px-2 py-1.5 text-xs rounded-md border transition-colors ${
+                                restrictHours === preset.hours
+                                  ? "bg-red-600 text-white border-red-600"
+                                  : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700"
+                              }`}
+                            >
+                              {preset.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                     <label className="block text-sm font-medium dark:text-gray-300">
                       {activeAction === "warn" ? (
                         <>
@@ -442,6 +493,13 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
                           className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-yellow-600 text-white hover:bg-yellow-700 disabled:opacity-50 transition-colors"
                         >
                           <AlertCircle size={12} /> Avisar al autor
+                        </button>
+                        <button
+                          onClick={() => setActiveAction("restrict")}
+                          disabled={isBusy}
+                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-rose-700 text-white hover:bg-rose-800 disabled:opacity-50 transition-colors"
+                        >
+                          <Ban size={12} /> Restringir autor
                         </button>
                         <button
                           onClick={() => hideMutation.mutate()}

--- a/src/features/reports/reportLabels.ts
+++ b/src/features/reports/reportLabels.ts
@@ -49,5 +49,6 @@ export const ACTION_TYPE_LABELS: Record<string, string> = {
   REJECT: "Rechazado",
   ESCALATE: "Escalado",
   WARN: "Advertencia al autor",
-  HIDE_CONTENT: "Contenido ocultado",
+  RESTRICT: "Restricción de cuenta",
+  HIDE: "Contenido ocultado",
 };


### PR DESCRIPTION
> ⛓️ **PR encadenado**: apila sobre `feat/reports-overhaul-slice1b-frontend` (PR #13, el drawer de moderación). Mergear el #13 primero; este PR debe re-targetearse a `release/v1.0` una vez mergeado el 1b.

## Qué

Slice 3b del rediseño de moderación (P1): la UI para **restringir temporalmente al autor** de un contenido reportado, consumiendo el endpoint del Slice 3a (backend, PR #17).

## Cómo

- `restrictUser(reportId, durationHours, note?)` en `reportApi`.
- Botón **"Restringir autor"** en el drawer de moderación (estados activos). Al seleccionarlo aparece un form con **presets de duración (24h / 7 días / 30 días)** + nota opcional, y confirma llamando al endpoint.
- La acción `RESTRICT` queda registrada en el audit trail existente del drawer.
- Fix de yapa: label de acción obsoleto (`HIDE_CONTENT` → `HIDE`) para que "ocultar" muestre "Contenido ocultado" y no el enum crudo.

## Tests

Nuevo `e2e/admin-restriction.spec.ts`: maneja la restricción por el drawer y verifica **enforcement real** — el autor restringido recibe **403** al intentar publicar un proyecto. Estable en repeticiones. Suite completa: **54 passed, 8 skipped, 0 failed**.

## Notas

- Depende del backend Slice 3a (PR #17) corriendo (ya rebuildeado en el stack local).
- Cierra el Slice 3 (3a backend + 3b frontend). El Slice 2 se saltó (el `hide` ya es soft-delete).
