### PR TITLE
feat(admin): suspend/reactivate/delete-account actions in the report drawer (Slice 4b)

### DIFF
--- a/e2e/admin-account-actions.spec.ts
+++ b/e2e/admin-account-actions.spec.ts
@@ -1,0 +1,254 @@
+import { test, expect } from '@playwright/test';
+import { apiRegisterAndLogin, apiLogin, apiCreateProject } from './helpers/api';
+import { injectAuth } from './helpers/auth';
+import { BASE_API_URL } from './helpers/constants';
+
+const RUN_ID = Date.now();
+
+interface ReportSetup {
+  adminToken: string;
+  devToken: string;
+  devUsername: string;
+  devPassword: string;
+  reporterToken: string;
+  reportId: number;
+  projectSlug: string;
+}
+
+/**
+ * Registra un dev autor + un dev reportero, publica un proyecto del autor,
+ * lo reporta y devuelve el id del reporte PENDING resultante (vía cola admin).
+ */
+async function setupReportedAccount(
+  request: import('@playwright/test').APIRequestContext,
+  prefix: string
+): Promise<ReportSetup> {
+  const devPassword = 'Password123!';
+  const devA = {
+    username: `${prefix}_a_${RUN_ID}`,
+    email: `${prefix}_a_${RUN_ID}@e2e.test`,
+    password: devPassword,
+    firstName: 'AcctA',
+    lastName: 'Autor',
+  };
+  const devToken = await apiRegisterAndLogin(request, devA).catch(async () =>
+    apiLogin(request, { username: devA.username, password: devA.password })
+  );
+
+  const target = await apiCreateProject(request, devToken, {
+    title: `${prefix} Objetivo ${RUN_ID}`,
+    subtitle: 'Objetivo del reporte',
+    description: 'Contenido reportado por dev B en test de acciones de cuenta.',
+    status: 'published',
+  });
+
+  const devB = {
+    username: `${prefix}_b_${RUN_ID}`,
+    email: `${prefix}_b_${RUN_ID}@e2e.test`,
+    password: 'Password123!',
+    firstName: 'AcctB',
+    lastName: 'Reporter',
+  };
+  const devBToken = await apiRegisterAndLogin(request, devB).catch(async () =>
+    apiLogin(request, { username: devB.username, password: devB.password })
+  );
+
+  const reportRes = await request.post(`${BASE_API_URL}/reports`, {
+    data: {
+      contentType: 'PROJECT',
+      contentId: target.id,
+      reason: 'SPAM',
+      description: 'E2E: reporte para test de acciones de cuenta.',
+    },
+    headers: { Authorization: `Bearer ${devBToken}` },
+  });
+  if (!reportRes.ok())
+    throw new Error(`No se pudo crear el reporte de setup: ${reportRes.status()}`);
+
+  const adminToken = await apiLogin(request, { username: 'admin', password: 'Admin123!' });
+
+  const reportsRes = await request.get(`${BASE_API_URL}/admin/reports`, {
+    params: { status: 'PENDING' },
+    headers: { Authorization: `Bearer ${adminToken}` },
+  });
+  if (!reportsRes.ok())
+    throw new Error(`No se pudo listar reportes PENDING: ${reportsRes.status()}`);
+  const reports = await reportsRes.json();
+  const ourReport = (reports as Array<{ id: number; contentAuthorUsername: string }>).find(
+    (r) => r.contentAuthorUsername === devA.username
+  );
+  if (!ourReport)
+    throw new Error('El reporte creado en el setup no apareció en la cola PENDING.');
+
+  return {
+    adminToken,
+    devToken,
+    devUsername: devA.username,
+    devPassword,
+    reporterToken: devBToken,
+    reportId: ourReport.id,
+    projectSlug: target.slug,
+  };
+}
+
+async function openReportDrawer(page: import('@playwright/test').Page, reportId: number) {
+  await page.goto('/admin');
+  await page.waitForURL('/admin', { timeout: 15000 });
+
+  // Ocultar el overlay de React Query Devtools (solo dev) que intercepta clicks.
+  await page.addStyleTag({
+    content: '.tsqd-parent-container { display: none !important; }',
+  });
+
+  await page.getByText('Reportes de contenido').waitFor({ timeout: 10000 });
+
+  const reportCard = page.locator(`[data-report-id="${reportId}"]`);
+  await expect(reportCard).toBeVisible({ timeout: 10000 });
+  await reportCard.click();
+
+  const drawer = page.locator('[data-testid="report-detail-drawer"]');
+  await expect(drawer).toBeVisible({ timeout: 10000 });
+  return drawer;
+}
+
+test.describe('Admin — Suspender / reactivar / eliminar cuenta desde el drawer', () => {
+  test('admin suspende desde el drawer y el login del suspendido devuelve 403 diferenciado', async ({
+    page,
+    request,
+  }) => {
+    const setup = await setupReportedAccount(request, 'susp');
+    await injectAuth(page, setup.adminToken);
+
+    const drawer = await openReportDrawer(page, setup.reportId);
+
+    await expect(drawer.locator('[data-testid="account-actions"]')).toBeVisible();
+    await drawer.getByRole('button', { name: /suspender cuenta/i }).click();
+    await drawer.getByRole('button', { name: /confirmar/i }).click();
+
+    // El audit trail debe registrar SUSPEND (verdad vía API).
+    await expect(async () => {
+      const detailRes = await page.request.get(
+        `${BASE_API_URL}/admin/reports/${setup.reportId}`,
+        { headers: { Authorization: `Bearer ${setup.adminToken}` } }
+      );
+      expect(detailRes.ok()).toBeTruthy();
+      const detail = await detailRes.json();
+      const types = (detail.auditTrail as Array<{ actionType: string }>).map((a) => a.actionType);
+      expect(types).toContain('SUSPEND');
+      expect(detail.report.contentAuthorAccountStatus).toBe('SUSPENDED');
+    }).toPass({ timeout: 15000 });
+
+    // El badge de estado de cuenta debe mostrar "Suspendida".
+    await expect(drawer.locator('[data-testid="account-status-badge"]')).toContainText(
+      /suspendida/i
+    );
+
+    // Login real del usuario suspendido → 403 con mensaje diferenciado.
+    const loginRes = await page.request.post(`${BASE_API_URL}/auth/login`, {
+      data: { username: setup.devUsername, password: setup.devPassword },
+    });
+    expect(loginRes.status()).toBe(403);
+    const loginBody = await loginRes.json();
+    expect(String(loginBody.message ?? '')).toMatch(/suspendida/i);
+  });
+
+  test('admin reactiva la cuenta desde el drawer y el login vuelve a funcionar', async ({
+    page,
+    request,
+  }) => {
+    const setup = await setupReportedAccount(request, 'react');
+
+    // Suspender por API para llegar directo al escenario de reactivación por UI.
+    const suspendRes = await request.post(
+      `${BASE_API_URL}/admin/reports/${setup.reportId}/suspend`,
+      { headers: { Authorization: `Bearer ${setup.adminToken}` } }
+    );
+    if (!suspendRes.ok())
+      throw new Error(`No se pudo suspender en el setup: ${suspendRes.status()}`);
+
+    await injectAuth(page, setup.adminToken);
+    const drawer = await openReportDrawer(page, setup.reportId);
+
+    await expect(drawer.locator('[data-testid="account-status-badge"]')).toContainText(
+      /suspendida/i
+    );
+    await drawer.getByRole('button', { name: /reactivar cuenta/i }).click();
+    await drawer.getByRole('button', { name: /confirmar/i }).click();
+
+    await expect(async () => {
+      const detailRes = await page.request.get(
+        `${BASE_API_URL}/admin/reports/${setup.reportId}`,
+        { headers: { Authorization: `Bearer ${setup.adminToken}` } }
+      );
+      expect(detailRes.ok()).toBeTruthy();
+      const detail = await detailRes.json();
+      const types = (detail.auditTrail as Array<{ actionType: string }>).map((a) => a.actionType);
+      expect(types).toContain('REACTIVATE');
+      expect(detail.report.contentAuthorAccountStatus).toBe('ACTIVE');
+    }).toPass({ timeout: 15000 });
+
+    const loginRes = await page.request.post(`${BASE_API_URL}/auth/login`, {
+      data: { username: setup.devUsername, password: setup.devPassword },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+  });
+
+  test('admin elimina la cuenta: el contenido deja de verse y no se ofrece reactivar', async ({
+    page,
+    request,
+  }) => {
+    const setup = await setupReportedAccount(request, 'del');
+    await injectAuth(page, setup.adminToken);
+
+    const drawer = await openReportDrawer(page, setup.reportId);
+
+    await drawer.getByRole('button', { name: /eliminar cuenta/i }).click();
+    await expect(drawer.locator('[data-testid="delete-account-warning"]')).toBeVisible();
+
+    // El botón de confirmar debe permanecer deshabilitado hasta tildar el checkbox.
+    const confirmButton = drawer.getByRole('button', { name: /confirmar/i });
+    await expect(confirmButton).toBeDisabled();
+    await drawer.getByRole('checkbox').check();
+    await expect(confirmButton).toBeEnabled();
+    await confirmButton.click();
+
+    await expect(async () => {
+      const detailRes = await page.request.get(
+        `${BASE_API_URL}/admin/reports/${setup.reportId}`,
+        { headers: { Authorization: `Bearer ${setup.adminToken}` } }
+      );
+      expect(detailRes.ok()).toBeTruthy();
+      const detail = await detailRes.json();
+      const types = (detail.auditTrail as Array<{ actionType: string }>).map((a) => a.actionType);
+      expect(types).toContain('DELETE_ACCOUNT');
+      expect(detail.report.contentAuthorAccountStatus).toBe('DELETED');
+    }).toPass({ timeout: 15000 });
+
+    // Badge "Eliminada" y sin botones de cuenta (ni "Reactivar").
+    await expect(drawer.locator('[data-testid="account-status-badge"]')).toContainText(
+      /eliminada/i
+    );
+    await expect(
+      drawer.getByRole('button', { name: /reactivar cuenta/i })
+    ).toHaveCount(0);
+    await expect(
+      drawer.getByRole('button', { name: /suspender cuenta/i })
+    ).toHaveCount(0);
+
+    // El contenido del autor eliminado deja de verse: un tercero autenticado
+    // (el reportero) ya no puede acceder al proyecto ocultado (403, project.status="hidden").
+    const projectRes = await page.request.get(
+      `${BASE_API_URL}/projects/${setup.projectSlug}`,
+      { headers: { Authorization: `Bearer ${setup.reporterToken}` } }
+    );
+    expect(projectRes.status()).toBe(403);
+
+    // Login del eliminado → 403 con mensaje diferenciado.
+    const loginRes = await page.request.post(`${BASE_API_URL}/auth/login`, {
+      data: { username: setup.devUsername, password: setup.devPassword },
+    });
+    expect(loginRes.status()).toBe(403);
+    const loginBody = await loginRes.json();
+    expect(String(loginBody.message ?? '')).toMatch(/eliminada/i);
+  });
+});

--- a/src/api/reportApi.ts
+++ b/src/api/reportApi.ts
@@ -123,6 +123,52 @@ export const hideReportedContent = async (reportId: number): Promise<void> => {
 };
 
 /**
+ * [ADMIN] Suspende la cuenta del autor del contenido reportado: bloquea el
+ * login de forma indefinida hasta que un admin la reactive. Reversible.
+ */
+export const suspendUser = async (
+  reportId: number,
+  note?: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/suspend`,
+    note ? { note } : {}
+  );
+  return data;
+};
+
+/**
+ * [ADMIN] Reactiva una cuenta previamente suspendida (restaura el login).
+ * No revierte una cuenta eliminada.
+ */
+export const reactivateUser = async (
+  reportId: number,
+  note?: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/reactivate`,
+    note ? { note } : {}
+  );
+  return data;
+};
+
+/**
+ * [ADMIN] Elimina la cuenta del autor del contenido reportado: bloquea el
+ * login y oculta todo su contenido (proyectos, feedback, comentarios, kudos,
+ * mentorías, ofertas laborales). Efectivamente irreversible.
+ */
+export const deleteAccount = async (
+  reportId: number,
+  note?: string
+): Promise<AdminReport> => {
+  const { data } = await apiService.post<AdminReport>(
+    `/admin/reports/${reportId}/delete-account`,
+    note ? { note } : {}
+  );
+  return data;
+};
+
+/**
  * [ADMIN] (Legacy) Marca un reporte como revisado o descartado, con mensaje opcional.
  * @deprecated Usar las acciones específicas (resolveReport, rejectReport, etc.) en su lugar.
  */

--- a/src/features/admin/components/ReportDetailDrawer.tsx
+++ b/src/features/admin/components/ReportDetailDrawer.tsx
@@ -13,6 +13,9 @@ import {
   AlertCircle,
   EyeOff,
   Ban,
+  UserX,
+  UserCheck,
+  Trash2,
 } from "lucide-react";
 import {
   fetchReportDetail,
@@ -23,6 +26,9 @@ import {
   warnContentOwner,
   restrictUser,
   hideReportedContent,
+  suspendUser,
+  reactivateUser,
+  deleteAccount,
 } from "../../../api/reportApi";
 import {
   REASON_LABELS,
@@ -30,6 +36,8 @@ import {
   STATUS_LABELS,
   STATUS_BADGE,
   ACTION_TYPE_LABELS,
+  ACCOUNT_STATUS_LABELS,
+  ACCOUNT_STATUS_BADGE,
 } from "../../reports/reportLabels";
 import type { AdminReport, ReportDetail, ReportStatus } from "../../../types";
 
@@ -38,7 +46,16 @@ interface ReportDetailDrawerProps {
   onClose: () => void;
 }
 
-type ActiveAction = "resolve" | "reject" | "escalate" | "warn" | "restrict" | null;
+type ActiveAction =
+  | "resolve"
+  | "reject"
+  | "escalate"
+  | "warn"
+  | "restrict"
+  | "suspend"
+  | "reactivate"
+  | "delete"
+  | null;
 
 const TERMINAL_STATUSES: ReportStatus[] = ["RESOLVED", "REJECTED"];
 const ACTIVE_STATUSES: ReportStatus[] = ["PENDING", "IN_REVIEW", "ESCALATED"];
@@ -57,6 +74,7 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
   const [restrictHours, setRestrictHours] = useState<number>(
     RESTRICTION_PRESETS[0].hours
   );
+  const [deleteConfirmed, setDeleteConfirmed] = useState(false);
 
   // Cerrar el drawer con la tecla Escape (a11y).
   useEffect(() => {
@@ -147,6 +165,40 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
     onError: onActionError,
   });
 
+  const suspendMutation = useMutation({
+    mutationFn: (n?: string) => suspendUser(reportId, n),
+    onSuccess: () => {
+      invalidateAll();
+      setActiveAction(null);
+      setNote("");
+      toast.success("Cuenta suspendida.");
+    },
+    onError: onActionError,
+  });
+
+  const reactivateMutation = useMutation({
+    mutationFn: (n?: string) => reactivateUser(reportId, n),
+    onSuccess: () => {
+      invalidateAll();
+      setActiveAction(null);
+      setNote("");
+      toast.success("Cuenta reactivada.");
+    },
+    onError: onActionError,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (n?: string) => deleteAccount(reportId, n),
+    onSuccess: () => {
+      invalidateAll();
+      setActiveAction(null);
+      setNote("");
+      setDeleteConfirmed(false);
+      toast.success("Cuenta eliminada.");
+    },
+    onError: onActionError,
+  });
+
   const isBusy =
     claimMutation.isPending ||
     resolveMutation.isPending ||
@@ -154,7 +206,10 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
     escalateMutation.isPending ||
     warnMutation.isPending ||
     restrictMutation.isPending ||
-    hideMutation.isPending;
+    hideMutation.isPending ||
+    suspendMutation.isPending ||
+    reactivateMutation.isPending ||
+    deleteMutation.isPending;
 
   const handleConfirmAction = () => {
     if (!activeAction) return;
@@ -172,6 +227,16 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
       rejectMutation.mutate(note.trim() || undefined);
     } else if (activeAction === "escalate") {
       escalateMutation.mutate(note.trim() || undefined);
+    } else if (activeAction === "suspend") {
+      suspendMutation.mutate(note.trim() || undefined);
+    } else if (activeAction === "reactivate") {
+      reactivateMutation.mutate(note.trim() || undefined);
+    } else if (activeAction === "delete") {
+      if (!deleteConfirmed) {
+        toast.error("Debés confirmar que entendés que esta acción es irreversible.");
+        return;
+      }
+      deleteMutation.mutate(note.trim() || undefined);
     }
   };
 
@@ -179,10 +244,12 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
     setActiveAction(null);
     setNote("");
     setRestrictHours(RESTRICTION_PRESETS[0].hours);
+    setDeleteConfirmed(false);
   };
 
   const report = detail?.report;
   const currentStatus = report?.status;
+  const accountStatus = report?.contentAuthorAccountStatus ?? null;
 
   return (
     <>
@@ -256,7 +323,21 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
                   )}
                 </InfoRow>
                 {report.contentAuthorUsername && (
-                  <InfoRow label="Autor" value={report.contentAuthorUsername} />
+                  <InfoRow label="Autor">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium dark:text-gray-200">
+                        {report.contentAuthorUsername}
+                      </span>
+                      {accountStatus && accountStatus !== "ACTIVE" && (
+                        <span
+                          data-testid="account-status-badge"
+                          className={`px-2 py-0.5 text-xs rounded-full font-medium ${ACCOUNT_STATUS_BADGE[accountStatus]}`}
+                        >
+                          {ACCOUNT_STATUS_LABELS[accountStatus]}
+                        </span>
+                      )}
+                    </div>
+                  </InfoRow>
                 )}
               </DrawerSection>
 
@@ -376,144 +457,219 @@ const ReportDetailDrawer = ({ reportId, onClose }: ReportDetailDrawerProps) => {
         {/* Footer con acciones */}
         {report && (
           <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 p-4 space-y-3">
-            {TERMINAL_STATUSES.includes(currentStatus!) ? (
-              <p className="text-sm text-center text-gray-500 dark:text-gray-400">
-                Este reporte está cerrado ({STATUS_LABELS[currentStatus!]}).
-              </p>
-            ) : (
-              <>
-                {/* Formulario de nota inline (aparece al seleccionar acción) */}
-                {activeAction && (
-                  <div className="space-y-2">
-                    {activeAction === "restrict" && (
-                      <div className="space-y-1.5">
-                        <span className="block text-sm font-medium dark:text-gray-300">
-                          Duración de la restricción
-                        </span>
-                        <div className="flex gap-2" data-testid="restrict-presets">
-                          {RESTRICTION_PRESETS.map((preset) => (
-                            <button
-                              key={preset.hours}
-                              type="button"
-                              onClick={() => setRestrictHours(preset.hours)}
-                              className={`flex-1 px-2 py-1.5 text-xs rounded-md border transition-colors ${
-                                restrictHours === preset.hours
-                                  ? "bg-red-600 text-white border-red-600"
-                                  : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700"
-                              }`}
-                            >
-                              {preset.label}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
+            {/* Acciones de cuenta: SIEMPRE visibles, sin importar el estado del
+                reporte (reactivar debe poder usarse aunque el reporte esté
+                cerrado). Independientes del bloque de acciones sobre el reporte. */}
+            {accountStatus && (
+              <div
+                className="pb-3 border-b border-gray-200 dark:border-gray-700 space-y-2"
+                data-testid="account-actions"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Cuenta del autor
+                  </span>
+                  <span
+                    className={`px-2 py-0.5 text-xs rounded-full font-medium ${ACCOUNT_STATUS_BADGE[accountStatus]}`}
+                  >
+                    {ACCOUNT_STATUS_LABELS[accountStatus]}
+                  </span>
+                </div>
+                {!activeAction && accountStatus === "DELETED" && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Esta cuenta fue eliminada. No hay más acciones disponibles.
+                  </p>
+                )}
+                {!activeAction && accountStatus !== "DELETED" && (
+                  <div className="flex flex-wrap gap-2">
+                    {accountStatus === "SUSPENDED" ? (
+                      <button
+                        onClick={() => setActiveAction("reactivate")}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+                      >
+                        <UserCheck size={12} /> Reactivar cuenta
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => setActiveAction("suspend")}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-rose-700 text-white hover:bg-rose-800 disabled:opacity-50 transition-colors"
+                      >
+                        <UserX size={12} /> Suspender cuenta
+                      </button>
                     )}
-                    <label className="block text-sm font-medium dark:text-gray-300">
-                      {activeAction === "warn" ? (
-                        <>
-                          Nota para el autor{" "}
-                          <span className="text-red-500">*</span>
-                        </>
-                      ) : (
-                        "Nota (opcional)"
-                      )}
-                    </label>
-                    <textarea
-                      value={note}
-                      onChange={(e) => setNote(e.target.value)}
-                      rows={2}
-                      maxLength={500}
-                      placeholder={
-                        activeAction === "warn"
-                          ? "Explica la advertencia al autor (requerido)..."
-                          : "Motivo de la acción (opcional)..."
-                      }
-                      className="w-full rounded-md bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-400 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 dark:focus:border-cyan-500 resize-none"
-                    />
-                    <div className="flex gap-2 justify-end">
-                      <button
-                        onClick={cancelAction}
-                        className="px-3 py-1.5 text-xs rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
-                      >
-                        Cancelar
-                      </button>
-                      <button
-                        onClick={handleConfirmAction}
-                        disabled={
-                          isBusy ||
-                          (activeAction === "warn" && !note.trim())
-                        }
-                        className="px-3 py-1.5 text-xs rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
-                      >
-                        {isBusy ? "Procesando..." : "Confirmar"}
-                      </button>
+                    <button
+                      onClick={() => setActiveAction("delete")}
+                      disabled={isBusy}
+                      className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-red-800 text-white hover:bg-red-900 disabled:opacity-50 transition-colors"
+                    >
+                      <Trash2 size={12} /> Eliminar cuenta
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Formulario de nota inline (aparece al seleccionar acción, sea
+                de reporte o de cuenta) */}
+            {activeAction && (
+              <div className="space-y-2">
+                {activeAction === "restrict" && (
+                  <div className="space-y-1.5">
+                    <span className="block text-sm font-medium dark:text-gray-300">
+                      Duración de la restricción
+                    </span>
+                    <div className="flex gap-2" data-testid="restrict-presets">
+                      {RESTRICTION_PRESETS.map((preset) => (
+                        <button
+                          key={preset.hours}
+                          type="button"
+                          onClick={() => setRestrictHours(preset.hours)}
+                          className={`flex-1 px-2 py-1.5 text-xs rounded-md border transition-colors ${
+                            restrictHours === preset.hours
+                              ? "bg-red-600 text-white border-red-600"
+                              : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700"
+                          }`}
+                        >
+                          {preset.label}
+                        </button>
+                      ))}
                     </div>
                   </div>
                 )}
-
-                {/* Botones de acción (se ocultan cuando hay un activeAction) */}
-                {!activeAction && (
-                  <div className="flex flex-wrap gap-2">
-                    {currentStatus === "PENDING" && (
-                      <button
-                        onClick={() => claimMutation.mutate()}
-                        disabled={isBusy}
-                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
-                      >
-                        <Shield size={12} /> Reclamar
-                      </button>
-                    )}
-
-                    {ACTIVE_STATUSES.includes(currentStatus!) && (
-                      <>
-                        <button
-                          onClick={() => setActiveAction("resolve")}
-                          disabled={isBusy}
-                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50 transition-colors"
-                        >
-                          <CheckCircle size={12} /> Resolver
-                        </button>
-                        <button
-                          onClick={() => setActiveAction("reject")}
-                          disabled={isBusy}
-                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-gray-600 text-white hover:bg-gray-700 disabled:opacity-50 transition-colors"
-                        >
-                          <XCircle size={12} /> Rechazar
-                        </button>
-                        <button
-                          onClick={() => setActiveAction("escalate")}
-                          disabled={isBusy}
-                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50 transition-colors"
-                        >
-                          <AlertTriangle size={12} /> Escalar
-                        </button>
-                        <button
-                          onClick={() => setActiveAction("warn")}
-                          disabled={isBusy}
-                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-yellow-600 text-white hover:bg-yellow-700 disabled:opacity-50 transition-colors"
-                        >
-                          <AlertCircle size={12} /> Avisar al autor
-                        </button>
-                        <button
-                          onClick={() => setActiveAction("restrict")}
-                          disabled={isBusy}
-                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-rose-700 text-white hover:bg-rose-800 disabled:opacity-50 transition-colors"
-                        >
-                          <Ban size={12} /> Restringir autor
-                        </button>
-                        <button
-                          onClick={() => hideMutation.mutate()}
-                          disabled={isBusy}
-                          className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
-                        >
-                          <EyeOff size={12} /> Ocultar contenido
-                        </button>
-                      </>
-                    )}
+                {activeAction === "delete" && (
+                  <div
+                    className="space-y-2 p-2 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800"
+                    data-testid="delete-account-warning"
+                  >
+                    <p className="text-xs text-red-700 dark:text-red-300 font-medium">
+                      Esta acción es irreversible: la cuenta quedará
+                      eliminada, se bloqueará su inicio de sesión y todo su
+                      contenido (proyectos, feedback, comentarios, kudos,
+                      mentorías, ofertas laborales) dejará de ser visible.
+                    </p>
+                    <label className="flex items-center gap-2 text-xs text-gray-700 dark:text-gray-300">
+                      <input
+                        type="checkbox"
+                        checked={deleteConfirmed}
+                        onChange={(e) => setDeleteConfirmed(e.target.checked)}
+                      />
+                      Entiendo que esta acción es irreversible.
+                    </label>
                   </div>
                 )}
-              </>
+                <label className="block text-sm font-medium dark:text-gray-300">
+                  {activeAction === "warn" ? (
+                    <>
+                      Nota para el autor{" "}
+                      <span className="text-red-500">*</span>
+                    </>
+                  ) : (
+                    "Nota (opcional)"
+                  )}
+                </label>
+                <textarea
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  rows={2}
+                  maxLength={500}
+                  placeholder={
+                    activeAction === "warn"
+                      ? "Explica la advertencia al autor (requerido)..."
+                      : "Motivo de la acción (opcional)..."
+                  }
+                  className="w-full rounded-md bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-400 px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 dark:focus:border-cyan-500 resize-none"
+                />
+                <div className="flex gap-2 justify-end">
+                  <button
+                    onClick={cancelAction}
+                    className="px-3 py-1.5 text-xs rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    Cancelar
+                  </button>
+                  <button
+                    onClick={handleConfirmAction}
+                    disabled={
+                      isBusy ||
+                      (activeAction === "warn" && !note.trim()) ||
+                      (activeAction === "delete" && !deleteConfirmed)
+                    }
+                    className="px-3 py-1.5 text-xs rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                  >
+                    {isBusy ? "Procesando..." : "Confirmar"}
+                  </button>
+                </div>
+              </div>
             )}
+
+            {/* Acciones sobre el reporte: gateadas por su estado (no aplica a
+                las acciones de cuenta, que viven arriba). */}
+            {!activeAction &&
+              (TERMINAL_STATUSES.includes(currentStatus!) ? (
+                <p className="text-sm text-center text-gray-500 dark:text-gray-400">
+                  Este reporte está cerrado ({STATUS_LABELS[currentStatus!]}).
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {currentStatus === "PENDING" && (
+                    <button
+                      onClick={() => claimMutation.mutate()}
+                      disabled={isBusy}
+                      className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                    >
+                      <Shield size={12} /> Reclamar
+                    </button>
+                  )}
+
+                  {ACTIVE_STATUSES.includes(currentStatus!) && (
+                    <>
+                      <button
+                        onClick={() => setActiveAction("resolve")}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+                      >
+                        <CheckCircle size={12} /> Resolver
+                      </button>
+                      <button
+                        onClick={() => setActiveAction("reject")}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-gray-600 text-white hover:bg-gray-700 disabled:opacity-50 transition-colors"
+                      >
+                        <XCircle size={12} /> Rechazar
+                      </button>
+                      <button
+                        onClick={() => setActiveAction("escalate")}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50 transition-colors"
+                      >
+                        <AlertTriangle size={12} /> Escalar
+                      </button>
+                      <button
+                        onClick={() => setActiveAction("warn")}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-yellow-600 text-white hover:bg-yellow-700 disabled:opacity-50 transition-colors"
+                      >
+                        <AlertCircle size={12} /> Avisar al autor
+                      </button>
+                      <button
+                        onClick={() => setActiveAction("restrict")}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-rose-700 text-white hover:bg-rose-800 disabled:opacity-50 transition-colors"
+                      >
+                        <Ban size={12} /> Restringir autor
+                      </button>
+                      <button
+                        onClick={() => hideMutation.mutate()}
+                        disabled={isBusy}
+                        className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+                      >
+                        <EyeOff size={12} /> Ocultar contenido
+                      </button>
+                    </>
+                  )}
+                </div>
+              ))}
           </div>
         )}
       </div>

--- a/src/features/reports/reportLabels.ts
+++ b/src/features/reports/reportLabels.ts
@@ -1,4 +1,4 @@
-import type { ReportContentType, ReportReason, ReportStatus } from "../../types";
+import type { AccountStatus, ReportContentType, ReportReason, ReportStatus } from "../../types";
 
 /** Etiquetas en español de los motivos de reporte (espejo del enum del back). */
 export const REASON_LABELS: Record<ReportReason, string> = {
@@ -51,4 +51,24 @@ export const ACTION_TYPE_LABELS: Record<string, string> = {
   WARN: "Advertencia al autor",
   RESTRICT: "Restricción de cuenta",
   HIDE: "Contenido ocultado",
+  SUSPEND: "Cuenta suspendida",
+  REACTIVATE: "Cuenta reactivada",
+  DELETE_ACCOUNT: "Cuenta eliminada",
+};
+
+/** Etiquetas en español del estado de cuenta del autor del contenido reportado. */
+export const ACCOUNT_STATUS_LABELS: Record<AccountStatus, string> = {
+  ACTIVE: "Activa",
+  SUSPENDED: "Suspendida",
+  DELETED: "Eliminada",
+};
+
+/** Clases Tailwind para el badge de estado de cuenta en modo claro y oscuro. */
+export const ACCOUNT_STATUS_BADGE: Record<AccountStatus, string> = {
+  ACTIVE:
+    "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
+  SUSPENDED:
+    "bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300",
+  DELETED:
+    "bg-gray-300 text-gray-800 dark:bg-gray-700 dark:text-gray-200",
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -248,6 +248,9 @@ export type ReportStatus =
   | "REJECTED"
   | "ESCALATED";
 
+/** Estado de la cuenta del autor del contenido reportado. */
+export type AccountStatus = "ACTIVE" | "SUSPENDED" | "DELETED";
+
 /** Vista admin de un reporte, con el contenido resuelto por el backend. */
 export interface AdminReport {
   id: number;
@@ -262,6 +265,7 @@ export interface AdminReport {
   contentLink: string | null;
   contentAuthorUsername: string | null;
   adminMessage?: string | null;
+  contentAuthorAccountStatus: AccountStatus | null;
 }
 
 /** Entrada del registro de moderación (audit trail). */


### PR DESCRIPTION
> ⛓️ **PR encadenado (3/3, último eslabón)**: cierra el Slice 4 de reports-overhaul (stacked-to-main). Depende de los tres endpoints y del campo `contentAuthorAccountStatus` ya mergeados en el backend (`main`): PR #18 + #19 (suspender/reactivar + login diferenciado) y PR #20 + #21 (eliminar cuenta + soft-hide en cascada, incluidos los fixes de judgment-day para replies/kudos/mentorías/ofertas).

```
4a-i (backend, main) ──▶ 4a-ii (backend, main) ──▶ 4b (frontend, release/v1.0) 📍
   PR #18 + #19              PR #20 + #21              este PR
```

## Qué

Slice 4b: acciones de cuenta sobre el autor del contenido reportado, disponibles desde el drawer de moderación —**Suspender**, **Reactivar** y **Eliminar cuenta**— más el estado de cuenta del autor visible en el detalle del reporte.

## Cómo

- `reportApi`: `suspendUser`, `reactivateUser`, `deleteAccount(reportId, note?)` — mismo patrón que `restrictUser`/`hideReportedContent`.
- `types/index.ts`: `AdminReport.contentAuthorAccountStatus: "ACTIVE" | "SUSPENDED" | "DELETED" | null`.
- `ReportDetailDrawer`:
  - Sección de **cuenta del autor** con badge de estado, **siempre visible** (fuera del bloque gateado por el estado del reporte) — reactivar debe poder usarse aunque el reporte ya esté cerrado.
  - Render condicional de botones: `ACTIVE` → "Suspender cuenta"; `SUSPENDED` → "Reactivar cuenta" + "Eliminar cuenta"; `DELETED` → solo badge, sin acciones (reactivar no revierte una eliminación).
  - "Eliminar cuenta" exige un checkbox explícito de confirmación (irreversible) antes de habilitar "Confirmar".
  - Nuevas etiquetas de audit trail (`SUSPEND`, `REACTIVATE`, `DELETE_ACCOUNT`) en `reportLabels`.

## Tests

Nuevo `e2e/admin-account-actions.spec.ts` (3 escenarios, contra backend local rebuildeado con V11):
- admin suspende por drawer → login del suspendido devuelve 403 con mensaje diferenciado ("suspendida").
- admin reactiva por drawer → login vuelve a funcionar.
- admin elimina por drawer (con checkbox obligatorio) → el contenido deja de ser accesible para terceros (403 al ver el proyecto oculto), no se ofrece "Reactivar", y el login devuelve 403 ("eliminada").

Suites corridas en verde: `admin-account-actions.spec.ts` (3/3), `admin-restriction.spec.ts` + `auth.spec.ts` (8/8), `admin-moderation.spec.ts` + `admin.spec.ts` (5 passed, 2 skipped preexistentes).

## Notas / fuera de alcance

- Requiere el backend local rebuildeado desde `main` post-#21 (migración V11 incluida) para correr los E2E.
- El diff de `ReportDetailDrawer.tsx` es más grande de lo estimado (~250 líneas) porque restructurar el footer para que la sección de cuenta quede siempre visible movió el bloque de botones de acción del reporte, contando como delete+insert en el diff — el cambio funcional neto es más chico de lo que sugiere el stat.
- Cierra el Slice 4 (suspensión + eliminación de cuenta) y el épico reports-overhaul. Siguiente: sdd-verify del slice completo → archive.