### PR TITLE
feat(profile): visibilidad de perfil en 4 modos (selector + reconciliación 404)

### DIFF
--- a/e2e/kudos.spec.ts
+++ b/e2e/kudos.spec.ts
@@ -50,7 +50,7 @@ test.describe('Kudos', () => {
         headline: 'E2E Test User',
         slug: knownSlug,
         bio: 'Usuario de prueba E2E.',
-        publicProfile: true,
+        profileVisibility: 'PUBLIC',
         socialLinks: [],
         techStackIds: [],
         workExperiences: [],

--- a/e2e/portfolio-visibility.spec.ts
+++ b/e2e/portfolio-visibility.spec.ts
@@ -149,6 +149,18 @@ test.describe('Matriz de visibilidad de portafolio', () => {
     await expect(page.locator(NOT_AVAILABLE_TESTID)).toBeVisible({ timeout: 10000 });
   });
 
+  test('INCUBADORA: un DEV no-owner logueado puede ver el portafolio', async ({ page, request }) => {
+    await setOwnerVisibility(request, 'INCUBADORA');
+    await injectAuth(page, otherDevToken);
+    await page.goto(`/portfolio/${ownerSlug}`);
+    await waitForPortfolioSettled(page);
+
+    await expect(page.locator(NOT_AVAILABLE_TESTID)).toHaveCount(0);
+    await expect(
+      page.getByText(new RegExp(`${OWNER.firstName}|${OWNER.lastName}`, 'i')).first()
+    ).toBeVisible({ timeout: 10000 });
+  });
+
   test('APPLICANT: un DEV no-owner es denegado (404 amable)', async ({ page, request }) => {
     await setOwnerVisibility(request, 'APPLICANT');
     await injectAuth(page, otherDevToken);

--- a/e2e/portfolio-visibility.spec.ts
+++ b/e2e/portfolio-visibility.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { apiLogin, apiRegisterAndLogin } from './helpers/api';
+import { injectAuth } from './helpers/auth';
+import { BASE_API_URL } from './helpers/constants';
+
+/**
+ * Matriz de acceso por visibilidad de perfil (portfolio-visibility, P2).
+ *
+ * Cubre las 7 combinaciones mínimas exigidas por la spec (NFR "E2E coverage
+ * per boundary") más la visibilidad de las advertencias del selector en
+ * /settings. Toda denegación (perfil inexistente o modo no visible para el
+ * requester) es 404 uniforme — ver PortfolioPage.tsx.
+ *
+ * Cuentas seed reutilizadas de otras suites (ver authorization.spec.ts):
+ *   admin       / Admin123!  → ADMINISTRATOR
+ *   steve-wozniak / Dev123!  → RECRUITER
+ */
+
+const PREFIX = 'pv';
+
+const OWNER = {
+  username: `${PREFIX}_owner`,
+  email: `${PREFIX}_owner@e2e.test`,
+  password: 'Password123!',
+  firstName: 'Visibility',
+  lastName: 'Owner',
+};
+
+const OTHER_DEV = {
+  username: `${PREFIX}_other_dev`,
+  email: `${PREFIX}_other_dev@e2e.test`,
+  password: 'Password123!',
+  firstName: 'Other',
+  lastName: 'Dev',
+};
+
+const NOT_AVAILABLE_TESTID = '[data-testid="portfolio-not-available"]';
+
+let ownerToken: string;
+let ownerSlug: string;
+let otherDevToken: string;
+let recruiterToken: string;
+let adminToken: string;
+
+/**
+ * Cambia el modo de visibilidad del perfil del owner via API, preservando
+ * el resto de los campos (el backend reemplaza el perfil entero en el PUT).
+ */
+async function setOwnerVisibility(
+  request: APIRequestContext,
+  visibility: 'PUBLIC' | 'INCUBADORA' | 'APPLICANT' | 'PRIVATE'
+) {
+  const profileRes = await request.get(`${BASE_API_URL}/profile`, {
+    headers: { Authorization: `Bearer ${ownerToken}` },
+  });
+  const profile = await profileRes.json();
+
+  const response = await request.put(`${BASE_API_URL}/profile`, {
+    data: {
+      headline: profile.headline ?? '',
+      slug: profile.slug,
+      bio: profile.bio ?? '',
+      profileVisibility: visibility,
+      socialLinks: (profile.socialLinks ?? []).map(
+        ({ platform, url }: { platform: string; url: string }) => ({ platform, url })
+      ),
+      techStackIds: (profile.techStack ?? []).map((t: { id: number }) => t.id),
+      workExperiences: (profile.workExperiences ?? []).map(
+        (exp: {
+          companyName: string;
+          position: string;
+          description: string;
+          startYear: number;
+          endYear?: number;
+        }) => ({
+          companyName: exp.companyName,
+          position: exp.position,
+          description: exp.description,
+          startYear: exp.startYear,
+          endYear: exp.endYear,
+        })
+      ),
+      languages: (profile.languages ?? []).map(
+        (l: { language: string; proficiency: string }) => ({
+          language: l.language,
+          proficiency: l.proficiency,
+        })
+      ),
+      certificates: (profile.certificates ?? []).map(
+        (c: { name: string; imageUrl: string; certificateUrl: string }) => ({
+          name: c.name,
+          imageUrl: c.imageUrl,
+          certificateUrl: c.certificateUrl,
+        })
+      ),
+    },
+    headers: { Authorization: `Bearer ${ownerToken}` },
+  });
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`setOwnerVisibility(${visibility}) failed (${response.status()}): ${body}`);
+  }
+}
+
+/** Espera a que el spinner de carga desaparezca antes de inspeccionar el body. */
+async function waitForPortfolioSettled(page: import('@playwright/test').Page) {
+  await page
+    .waitForFunction(
+      () => !document.body.innerText.toLowerCase().includes('cargando'),
+      { timeout: 20000 }
+    )
+    .catch(() => {});
+}
+
+test.describe('Matriz de visibilidad de portafolio', () => {
+  test.beforeAll(async ({ request }) => {
+    ownerToken = await apiRegisterAndLogin(request, OWNER).catch(async () =>
+      apiLogin(request, { username: OWNER.username, password: OWNER.password })
+    );
+    otherDevToken = await apiRegisterAndLogin(request, OTHER_DEV).catch(async () =>
+      apiLogin(request, { username: OTHER_DEV.username, password: OTHER_DEV.password })
+    );
+    recruiterToken = await apiLogin(request, { username: 'steve-wozniak', password: 'Dev123!' });
+    adminToken = await apiLogin(request, { username: 'admin', password: 'Admin123!' });
+
+    const profileRes = await request.get(`${BASE_API_URL}/profile`, {
+      headers: { Authorization: `Bearer ${ownerToken}` },
+    });
+    const profile = await profileRes.json();
+    ownerSlug = profile.slug;
+  });
+
+  test('PUBLIC: un visitante anónimo puede ver el portafolio', async ({ page, request }) => {
+    await setOwnerVisibility(request, 'PUBLIC');
+    await page.goto(`/portfolio/${ownerSlug}`);
+    await waitForPortfolioSettled(page);
+
+    await expect(page.locator(NOT_AVAILABLE_TESTID)).toHaveCount(0);
+    await expect(
+      page.getByText(new RegExp(`${OWNER.firstName}|${OWNER.lastName}`, 'i')).first()
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('INCUBADORA: un visitante anónimo es denegado (404 amable)', async ({ page, request }) => {
+    await setOwnerVisibility(request, 'INCUBADORA');
+    await page.goto(`/portfolio/${ownerSlug}`);
+    await waitForPortfolioSettled(page);
+
+    await expect(page.locator(NOT_AVAILABLE_TESTID)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('APPLICANT: un DEV no-owner es denegado (404 amable)', async ({ page, request }) => {
+    await setOwnerVisibility(request, 'APPLICANT');
+    await injectAuth(page, otherDevToken);
+    await page.goto(`/portfolio/${ownerSlug}`);
+    await waitForPortfolioSettled(page);
+
+    await expect(page.locator(NOT_AVAILABLE_TESTID)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('APPLICANT: un RECRUITER puede ver el portafolio', async ({ page, request }) => {
+    await setOwnerVisibility(request, 'APPLICANT');
+    await injectAuth(page, recruiterToken);
+    await page.goto(`/portfolio/${ownerSlug}`);
+    await waitForPortfolioSettled(page);
+
+    await expect(page.locator(NOT_AVAILABLE_TESTID)).toHaveCount(0);
+    await expect(
+      page.getByText(new RegExp(`${OWNER.firstName}|${OWNER.lastName}`, 'i')).first()
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('PRIVATE: un RECRUITER es denegado (404 amable)', async ({ page, request }) => {
+    await setOwnerVisibility(request, 'PRIVATE');
+    await injectAuth(page, recruiterToken);
+    await page.goto(`/portfolio/${ownerSlug}`);
+    await waitForPortfolioSettled(page);
+
+    await expect(page.locator(NOT_AVAILABLE_TESTID)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('PRIVATE: el owner puede ver su propio portafolio', async ({ page, request }) => {
+    await setOwnerVisibility(request, 'PRIVATE');
+    await injectAuth(page, ownerToken);
+    await page.goto(`/portfolio/${ownerSlug}`);
+    await waitForPortfolioSettled(page);
+
+    await expect(page.locator(NOT_AVAILABLE_TESTID)).toHaveCount(0);
+    await expect(
+      page.getByText(new RegExp(`${OWNER.firstName}|${OWNER.lastName}`, 'i')).first()
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('ADMINISTRATOR: bypassa la denegación en todos los modos', async ({ page, request }) => {
+    const modes = ['PUBLIC', 'INCUBADORA', 'APPLICANT', 'PRIVATE'] as const;
+    for (const mode of modes) {
+      await setOwnerVisibility(request, mode);
+      await injectAuth(page, adminToken);
+      await page.goto(`/portfolio/${ownerSlug}`);
+      await waitForPortfolioSettled(page);
+
+      await expect(page.locator(NOT_AVAILABLE_TESTID)).toHaveCount(0);
+      await expect(
+        page.getByText(new RegExp(`${OWNER.firstName}|${OWNER.lastName}`, 'i')).first()
+      ).toBeVisible({ timeout: 10000 });
+    }
+  });
+
+  test('/settings: muestra advertencia al elegir PUBLIC y al elegir PRIVATE', async ({ page }) => {
+    await injectAuth(page, ownerToken);
+    await page.goto('/settings');
+    await page.waitForURL('/settings', { timeout: 15000 });
+
+    const select = page.locator('#profileVisibility');
+    await expect(select).toBeVisible({ timeout: 10000 });
+
+    await select.selectOption('PUBLIC');
+    await expect(page.getByTestId('visibility-public-warning')).toBeVisible();
+    await expect(page.getByTestId('visibility-private-warning')).toHaveCount(0);
+
+    await select.selectOption('PRIVATE');
+    await expect(page.getByTestId('visibility-private-warning')).toBeVisible();
+    await expect(page.getByTestId('visibility-public-warning')).toHaveCount(0);
+
+    await select.selectOption('INCUBADORA');
+    await expect(page.getByTestId('visibility-public-warning')).toHaveCount(0);
+    await expect(page.getByTestId('visibility-private-warning')).toHaveCount(0);
+  });
+});

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -43,41 +43,31 @@ test.describe('Perfil y Portfolio', () => {
   });
 
   test('should display public portfolio without auth', async ({ page }) => {
-    // Sin autenticación, navegar al portfolio público
+    // Sin autenticación, navegar al portfolio público.
+    // Desde portfolio-visibility (P2) el default tras el registro es
+    // INCUBADORA (opt-in estricto a PUBLIC vía V12), por lo que un
+    // visitante anónimo debe ver el estado "no disponible" uniforme,
+    // no el contenido del perfil.
     await page.goto(`/portfolio/${userSlug}`);
-    // Esperar a que el spinner de carga desaparezca (la API debe resolver la petición)
     await page.waitForFunction(
       () => !document.body.innerText.toLowerCase().includes('cargando'),
       { timeout: 20000 }
     ).catch(() => {});
 
-    // El portfolio puede mostrar el nombre o un mensaje de "perfil privado" si
-    // el usuario no ha habilitado su perfil público
-    const hasContent = await page.getByText(
-      new RegExp(`${USER.firstName}|${USER.lastName}|${USER.username}`, 'i')
-    ).count() > 0;
-    const isPrivate = await page.getByText(/perfil es privado|no se encontró/i).count() > 0;
-    const hasError = await page.getByText(/error al cargar/i).count() > 0;
-    // Si el backend requiere auth para el portfolio, el interceptor de axios redirige a /login
-    const isRedirectedToLogin = page.url().includes('/login');
-
-    // Al menos una condición debe cumplirse (la página carga algo)
-    expect(hasContent || isPrivate || hasError || isRedirectedToLogin).toBeTruthy();
+    await expect(page.locator('[data-testid="portfolio-not-available"]')).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test('should return 404 or error for non-existent slug', async ({ page }) => {
     await page.goto('/portfolio/slug-que-no-existe-xyz-e2e-12345');
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
-    // El PortfolioPage muestra uno de estos mensajes para errores:
-    // 404 → "No se encontró este portfolio."
-    // 403 → "Este perfil es privado."
-    // Genérico → "Error al cargar el portfolio: ..."
-    // O el router → "Página No Encontrada"
-    const bodyText = await page.locator('body').innerText();
-    const hasError = /portfolio|privado|encontr|error|404/i.test(bodyText);
-
-    expect(hasError).toBeTruthy();
+    // El backend responde 404 uniforme tanto para slugs inexistentes como
+    // para accesos denegados por modo de visibilidad (portfolio-visibility, P2).
+    await expect(page.locator('[data-testid="portfolio-not-available"]')).toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test('should edit profile settings', async ({ page }) => {

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -8,7 +8,7 @@ export const queryKeys = {
 
   // Perfil
   userProfile: () => ["userProfile"] as const,
-  publicProfile: (slug: string) => ["publicProfile", slug] as const,
+  profileBySlug: (slug: string) => ["profileBySlug", slug] as const,
   portfolio: (slug: string) => ["portfolio", slug] as const,
   profile: (slug: string | undefined) => ["profile", slug] as const,
 

--- a/src/features/dashboard/pages/DeveloperDashboard.tsx
+++ b/src/features/dashboard/pages/DeveloperDashboard.tsx
@@ -15,6 +15,7 @@ import { ProjectCard } from "../../projects/components/ProjectCard";
 import { MentorshipCard } from "../../mentoring/components/MentorshipCard";
 import MentorshipForm from "../../mentoring/components/MentorshipForm";
 import type { ProjectSummary, MentorshipDetailResponse } from "../../../types";
+import { PROFILE_VISIBILITY_OPTIONS } from "../../../types";
 import { useState } from "react";
 import Modal from "../../../components/ui/modal/Modal";
 import ProjectForm from "../../projects/components/ProjectForm";
@@ -234,7 +235,10 @@ const DeveloperDashboard = () => {
               {user?.role}
             </span>
             <span className="text-text-soft dark:text-gray-400">
-              {data.publicProfile ? "Perfil público" : "Perfil privado"}
+              Visibilidad:{" "}
+              {PROFILE_VISIBILITY_OPTIONS.find(
+                (opt) => opt.value === data.profileVisibility
+              )?.label ?? data.profileVisibility}
             </span>
             {stats && (
               <span className="text-text-soft dark:text-gray-400">

--- a/src/features/profile/hooks/useInlineProfileEdit.ts
+++ b/src/features/profile/hooks/useInlineProfileEdit.ts
@@ -14,7 +14,7 @@ export const buildUpdateRequest = (
   headline: profile.headline ?? "",
   slug: profile.slug,
   bio: profile.bio ?? "",
-  publicProfile: profile.publicProfile,
+  profileVisibility: profile.profileVisibility,
   socialLinks: (profile.socialLinks ?? []).map(({ platform, url }) => ({
     platform,
     url,
@@ -51,7 +51,8 @@ export const useInlineProfileEdit = (profile: ProfileResponse | undefined) => {
     onSuccess: (updated) => {
       toast.success("Perfil actualizado");
       queryClient.setQueryData(["userProfile"], updated);
-      queryClient.invalidateQueries({ queryKey: ["publicProfile"] });
+      queryClient.invalidateQueries({ queryKey: ["profileBySlug"] });
+      queryClient.invalidateQueries({ queryKey: ["portfolio"] });
     },
     onError: (error) => {
       toast.error(`Error al guardar: ${error.message}`);

--- a/src/features/profile/pages/EditProfilePage.tsx
+++ b/src/features/profile/pages/EditProfilePage.tsx
@@ -9,12 +9,17 @@ import { useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
 import { fetchUserProfile, updateUserProfile } from "../../../api/profileApi";
 import { fetchTechnologies } from "../../../api/projectApi";
-import type { ImageUploadResponse, ProfileUpdateRequest, Technology } from "../../../types";
+import {
+  PROFILE_VISIBILITY_OPTIONS,
+  type ImageUploadResponse,
+  type ProfileUpdateRequest,
+  type Technology,
+} from "../../../types";
 import Loading from "../../../components/ux/Loading";
 import MultiSelect from "../../projects/components/MultiSelect";
 import ImageUpload from "../../../components/ui/ImageUpload";
 import { useEffect, useMemo } from "react";
-import { Trash2 } from "lucide-react";
+import { AlertTriangle, Trash2 } from "lucide-react";
 
 const EditProfilePage = () => {
   const navigate = useNavigate();
@@ -50,13 +55,14 @@ const EditProfilePage = () => {
     control,
     handleSubmit,
     reset,
+    watch,
     formState: { isSubmitting },
   } = useForm<ProfileUpdateRequest>({
     defaultValues: {
       headline: "",
       bio: "",
       slug: "",
-      publicProfile: true,
+      profileVisibility: "INCUBADORA",
       socialLinks: [],
       techStackIds: [],
       workExperiences: [],
@@ -109,7 +115,7 @@ const EditProfilePage = () => {
         headline: profileData.headline,
         slug: profileData.slug,
         bio: profileData.bio,
-        publicProfile: profileData.publicProfile,
+        profileVisibility: profileData.profileVisibility,
         socialLinks: profileData.socialLinks.map(({ ...rest }) => rest), // Omitir 'id'
         techStackIds: profileData.techStack.map((tech) => tech.id),
         workExperiences: profileData.workExperiences.map(({ ...rest }) => rest),
@@ -118,6 +124,9 @@ const EditProfilePage = () => {
       });
     }
   }, [profileData, reset]);
+
+  // Modo de visibilidad seleccionado actualmente (para mostrar advertencias)
+  const visibility = watch("profileVisibility");
 
   // 5. Mutación para enviar los datos actualizados
   const mutation = useMutation({
@@ -222,14 +231,58 @@ const EditProfilePage = () => {
               className="mt-1 block w-full border-gray-300 dark:border-gray-700 bg-bg-light dark:bg-bg-dark text-text-main dark:text-text-light rounded-md shadow-sm"
             />
           </div>
-          <div className="flex items-center gap-2">
-            <input
-              id="publicProfile"
-              type="checkbox"
-              {...register("publicProfile")}
-              className="rounded"
-            />
-            <label htmlFor="publicProfile">Hacer perfil público</label>
+          <div>
+            <label htmlFor="profileVisibility">Visibilidad del perfil</label>
+            <select
+              id="profileVisibility"
+              {...register("profileVisibility")}
+              className="mt-1 block w-full border-gray-300 dark:border-gray-700 bg-bg-light dark:bg-bg-dark text-text-main dark:text-text-light rounded-md shadow-sm"
+            >
+              {PROFILE_VISIBILITY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-text-soft dark:text-gray-400">
+              {
+                PROFILE_VISIBILITY_OPTIONS.find(
+                  (option) => option.value === visibility
+                )?.description
+              }
+            </p>
+            {visibility === "PUBLIC" && (
+              <div
+                data-testid="visibility-public-warning"
+                className="mt-2 flex items-start gap-2 p-2 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
+              >
+                <AlertTriangle
+                  size={16}
+                  className="text-amber-600 dark:text-amber-400 shrink-0 mt-0.5"
+                />
+                <p className="text-xs text-amber-700 dark:text-amber-300 font-medium">
+                  Con visibilidad Pública, cualquier persona en internet podrá
+                  ver tus datos personales y proyectos, incluso sin tener una
+                  cuenta.
+                </p>
+              </div>
+            )}
+            {visibility === "PRIVATE" && (
+              <div
+                data-testid="visibility-private-warning"
+                className="mt-2 flex items-start gap-2 p-2 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
+              >
+                <AlertTriangle
+                  size={16}
+                  className="text-amber-600 dark:text-amber-400 shrink-0 mt-0.5"
+                />
+                <p className="text-xs text-amber-700 dark:text-amber-300 font-medium">
+                  Con visibilidad Privada, otros devs no podrán darte
+                  reconocimientos (kudos) y los reclutadores no verán tu
+                  portafolio.
+                </p>
+              </div>
+            )}
           </div>
         </section>
 

--- a/src/features/profile/pages/PortfolioPage.tsx
+++ b/src/features/profile/pages/PortfolioPage.tsx
@@ -41,8 +41,9 @@ const PortfolioPage = () => {
     enabled: !!slug,
     staleTime: 1000 * 60 * 20,
     retry: (failureCount, err: any) => {
-      // No reintentar en 403 o 404
-      if (err?.response?.status === 403 || err?.response?.status === 404) {
+      // No reintentar en 404: el backend usa 404 uniforme para perfil
+      // inexistente y para acceso denegado por modo de visibilidad.
+      if (err?.response?.status === 404) {
         return false;
       }
       return failureCount < 2;
@@ -68,20 +69,17 @@ const PortfolioPage = () => {
 
   if (isError) {
     const status = (error as any)?.response?.status;
-    if (status === 403) {
-      return (
-        <div className="text-center p-8">
-          <p className="text-gray-600 dark:text-gray-400 text-lg">
-            Este perfil es privado.
-          </p>
-        </div>
-      );
-    }
+    // 404 uniforme: cubre tanto perfil inexistente/eliminado como acceso
+    // denegado por modo de visibilidad. Un único estado amable, sin
+    // distinguir el motivo (no revela si el perfil existe).
     if (status === 404) {
       return (
         <div className="text-center p-8">
-          <p className="text-gray-600 dark:text-gray-400 text-lg">
-            No se encontró este portfolio.
+          <p
+            className="text-gray-600 dark:text-gray-400 text-lg"
+            data-testid="portfolio-not-available"
+          >
+            Este perfil no está disponible.
           </p>
         </div>
       );

--- a/src/features/profile/pages/ProfilePage.tsx
+++ b/src/features/profile/pages/ProfilePage.tsx
@@ -95,7 +95,7 @@ const ProfilePage = () => {
     isError,
     error,
   } = useQuery({
-    queryKey: isPublicProfileView ? ["publicProfile", slug] : ["userProfile"],
+    queryKey: isPublicProfileView ? ["profileBySlug", slug] : ["userProfile"],
     queryFn: isPublicProfileView //si hay slug, se busca el perfil público
       ? () => fetchPublicProfileBySlug(slug!)
       : fetchUserProfile, //si no hay slug, se busca el perfil propio
@@ -107,7 +107,7 @@ const ProfilePage = () => {
   const isOwnProfile = !isPublicProfileView || ownProfileData?.slug === slug;
 
   // Edición inline: el body del PUT se arma sobre el perfil autenticado
-  // (no sobre la vista pública) para no perder campos como publicProfile.
+  // (no sobre la vista pública) para no perder campos como profileVisibility.
   const { saveProfile, isSaving } = useInlineProfileEdit(
     isOwnProfile ? ownProfileData ?? profile : undefined
   );
@@ -146,10 +146,10 @@ const ProfilePage = () => {
     );
   }
 
-  if (!isOwnProfile && !profile.publicProfile) {
+  if (!isOwnProfile && profile.profileVisibility !== "PUBLIC") {
     return (
       <div className="text-center p-8">
-        <p>Este perfil es privado.</p>
+        <p>Este perfil no está disponible.</p>
       </div>
     );
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,7 +66,7 @@ export const PROFILE_VISIBILITY_OPTIONS: ProfileVisibilityOption[] = [
     value: "APPLICANT",
     label: "Postulante",
     description:
-      "Solo reclutadores pueden ver tu portafolio al evaluar tu postulación.",
+      "Cualquier reclutador de la plataforma puede ver tu portafolio (además de administradores).",
   },
   {
     value: "PRIVATE",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,7 +71,8 @@ export const PROFILE_VISIBILITY_OPTIONS: ProfileVisibilityOption[] = [
   {
     value: "PRIVATE",
     label: "Privado",
-    description: "Nadie más puede ver tu portafolio; solo vos.",
+    description:
+      "Solo vos y los administradores de la plataforma pueden ver tu portafolio.",
   },
 ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,46 @@ export interface LoginRequest {
 * Profile
 ===================================================*/
 
+/** Modos de visibilidad del perfil/portafolio (matriz de acceso). */
+export type ProfileVisibility =
+  | "PUBLIC"
+  | "INCUBADORA"
+  | "APPLICANT"
+  | "PRIVATE";
+
+export interface ProfileVisibilityOption {
+  value: ProfileVisibility;
+  label: string;
+  description: string;
+}
+
+/** Opciones del selector de visibilidad, con etiqueta y descripción corta. */
+export const PROFILE_VISIBILITY_OPTIONS: ProfileVisibilityOption[] = [
+  {
+    value: "PUBLIC",
+    label: "Público",
+    description:
+      "Cualquier persona en internet puede ver tu portafolio, incluso sin cuenta.",
+  },
+  {
+    value: "INCUBADORA",
+    label: "Solo Incubadora",
+    description:
+      "Solo usuarios logueados en la plataforma pueden ver tu portafolio.",
+  },
+  {
+    value: "APPLICANT",
+    label: "Postulante",
+    description:
+      "Solo reclutadores pueden ver tu portafolio al evaluar tu postulación.",
+  },
+  {
+    value: "PRIVATE",
+    label: "Privado",
+    description: "Nadie más puede ver tu portafolio; solo vos.",
+  },
+];
+
 export interface ProfileResponse {
   slug: string;
   firstName: string;
@@ -45,7 +85,7 @@ export interface ProfileResponse {
   avatarThumbnailUrl?: string;
   bioImageUrl?: string;
   email: string;
-  publicProfile: boolean;
+  profileVisibility: ProfileVisibility;
   techStack: Technology[];
   socialLinks: SocialLink[];
   workExperiences: WorkExperience[];
@@ -115,7 +155,7 @@ export interface ProfileUpdateRequest {
   headline: string;
   slug: string;
   bio: string;
-  publicProfile: boolean;
+  profileVisibility: ProfileVisibility;
   socialLinks: Omit<SocialLink, "id">[];
   techStackIds: number[];
   workExperiences: Omit<WorkExperience, "id">[];


### PR DESCRIPTION
## Contexto (SDD portfolio-visibility, P2)

📍 **PR 2 de 2 (stacked-to-main)** — este PR es el frontend. Depende del PR de
backend (#22 en `incubadora-back`, ya mergeado a `main`), que introdujo el enum
`profileVisibility` (`PUBLIC` / `INCUBADORA` / `APPLICANT` / `PRIVATE`) y el
choke point `ProfileVisibilityService`.

## Resumen

- Reemplaza el checkbox "Hacer perfil público" por un selector de 4 modos en
  `/settings`, con descripción corta por modo y advertencias cuando se elige
  `PUBLIC` (exposición de datos) o `PRIVATE` (se pierden kudos y visibilidad
  para reclutadores).
- Reconcilia el denial de `PortfolioPage` (antes 403 "privado" / 404 "no
  encontrado") en un único estado 404 amable "Este perfil no está disponible",
  igual para slug inexistente y para acceso denegado por modo.
- Migra el tipo `ProfileResponse`/`ProfileUpdateRequest` de `publicProfile:
  boolean` a `profileVisibility: ProfileVisibility` y actualiza todos los
  consumidores.
- Agrega cobertura E2E (Playwright) de la matriz de acceso por modo ×
  audiencia (anónimo/DEV/RECRUITER/owner/ADMIN).

## Matriz de acceso (implementada en backend, verificada acá vía E2E)

| Modo | Anónimo | DEV/MENTOR | RECRUITER | Owner | ADMIN |
|---|---|---|---|---|---|
| PUBLIC | 200 | 200 | 200 | 200 | 200 |
| INCUBADORA | 404 | 200 | 200 | 200 | 200 |
| APPLICANT | 404 | 404 | 200 | 200 | 200 |
| PRIVATE | 404 | 404 | 404 | 200 | 200 |

## Cambios

| Archivo | Cambio |
|---|---|
| `src/types/index.ts` | `ProfileVisibility` type + `PROFILE_VISIBILITY_OPTIONS` (label/descripción); `profileVisibility` reemplaza `publicProfile` en `ProfileResponse`/`ProfileUpdateRequest` |
| `src/features/profile/pages/EditProfilePage.tsx` | Selector de 4 modos + advertencias condicionales (PUBLIC/PRIVATE) |
| `src/features/profile/pages/PortfolioPage.tsx` | Elimina la rama 403; único estado 404 "perfil no disponible" (`data-testid="portfolio-not-available"`) |
| `src/features/profile/pages/ProfilePage.tsx` | Corrige la referencia muerta a `publicProfile` (rama inalcanzable: la ruta `/profile` nunca recibe slug) |
| `src/features/dashboard/pages/DeveloperDashboard.tsx` | Label de visibilidad usa el modo real, no un booleano |
| `src/features/profile/hooks/useInlineProfileEdit.ts` | Payload del PUT usa `profileVisibility`; invalida las query keys correctas |
| `src/api/queryKeys.ts` | Renombra la key `publicProfile` (no usada) a `profileBySlug` |
| `e2e/portfolio-visibility.spec.ts` | Nuevo: 8 casos cubriendo la matriz completa + advertencias del selector |
| `e2e/profile.spec.ts` | Actualiza 2 asserts que dependían de la copy/default anteriores |
| `e2e/kudos.spec.ts` | Corrige el seed payload (`publicProfile` → `profileVisibility`) |

## Decisiones y desviaciones

- **`PortfolioPage.tsx` es la única superficie pública real** (`/portfolio/:slug`,
  sin auth requerida). `ProfilePage.tsx` también tiene una rama "vista pública"
  con slug (`isPublicProfileView`), pero el router nunca monta esa página con
  un `:slug` (la ruta es `/profile` a secas) — es código muerto preexistente.
  Lo dejé compilando con el campo correcto en vez de eliminarlo, para no
  ampliar el alcance de este PR.
- **`profile.spec.ts` (preexistente) rompía por dos motivos intencionales de
  este cambio**: (1) el default de visibilidad tras el registro pasó de
  público-por-defecto a `INCUBADORA` (opt-in estricto a `PUBLIC`, ya decidido
  en el PR de backend), y (2) la copy de denegación se consolidó en un único
  mensaje. Actualicé los 2 asserts afectados para usar el nuevo
  `data-testid="portfolio-not-available"` en vez de regex sobre texto viejo.
- **Tamaño del diff (~397 líneas) por encima del estimado (~120-160)**,
  principalmente por la suite E2E nueva (229 líneas) y el ajuste del test
  legacy. Sigue bajo el umbral de 400 y es un único deliverable (PR 2/2 ya
  decidido en tasks), así que no lo dividí más.

## Test plan

- `pnpm exec tsc -b`: sin errores.
- `pnpm lint`: 33 errores preexistentes (idénticos antes/después del cambio,
  verificado con `git stash`), 0 nuevos.
- `pnpm test:e2e e2e/portfolio-visibility.spec.ts`: **8/8 verde**.
- `pnpm test:e2e` (suite completa, contra backend local reconstruido desde
  `main` con el PR #22 ya mergeado, V12 confirmada aplicada): **66 passed, 8
  skipped (preexistente), 0 failed**.
