### PR TITLE
fix(profile): stop exposing private-inclusive kudo total on public portfolio

### DIFF
--- a/src/features/profile/pages/PortfolioPage.tsx
+++ b/src/features/profile/pages/PortfolioPage.tsx
@@ -263,11 +263,6 @@ const PortfolioPage = () => {
               <span className="text-sm text-gray-600 dark:text-gray-400">
                 {kudosReceived.length}
               </span>
-              {profile.stats && (
-                <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">
-                  ({profile.stats.totalKudosReceived} en total)
-                </span>
-              )}
               {/* Botón "Dar Kudo" solo para usuarios autenticados */}
               {isAuthenticated && (
                 <div className="flex w-auto justify-center ms-auto text-sm text-gray-500">


### PR DESCRIPTION
## Contexto

PR #19 (merged) agregó el render de `stats.totalKudosReceived` en el portfolio público. Judgment-day (dos jueces ciegos) confirmó que ese contador incluye kudos **privados** y no está gateado por ownership, así que un visitante anónimo podía **inferir la cantidad exacta de kudos privados** restando `totalKudosReceived - kudosReceived.length`. Además generaba un doble-contador confuso.

## Cambio

Remueve la anotación `(N en total)` del portfolio público. El total completo sigue mostrándose en el dashboard privado del dueño.

## Nota

El fix complementario de backend (gatear `totalKudosReceived` por ownership en `ProfileService`, para que el JSON público tampoco exponga el número) va en una PR separada en el repo backend.