### PR TITLE
test(e2e): add avatar upload and delete flow coverage

### DIFF
--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -94,6 +94,49 @@ test.describe('Perfil y Portfolio', () => {
     }
   });
 
+  test('should upload and delete avatar image', async ({ page }) => {
+    await injectAuth(page, authToken);
+    await page.goto('/settings');
+    await page.waitForURL('/settings', { timeout: 15000 });
+
+    // La sección "Avatar" y la de "Imagen de banner" comparten la misma
+    // estructura (ImageUpload en variante rectangle); se distinguen por el
+    // texto del label, ya que el componente no expone data-testid.
+    const avatarSection = page.locator('div.space-y-2').filter({ hasText: 'Avatar' }).first();
+    const fileInput = avatarSection.locator('input[type="file"]');
+
+    // PNG 1x1 válido embebido como buffer (no hay fixtures de imágenes en el repo).
+    const tinyPng = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      'base64'
+    );
+    await fileInput.setInputFiles({
+      name: 'avatar.png',
+      mimeType: 'image/png',
+      buffer: tinyPng,
+    });
+
+    // Confirmar la subida (toast + invalidación de la query userProfile).
+    await expect(page.getByText('Avatar actualizado correctamente.')).toBeVisible({ timeout: 15000 });
+
+    // El botón "Eliminar imagen" solo se muestra cuando hay currentImageUrl
+    // Y no hay preview local activo; tras subir, el preview local del blob
+    // sigue seteado, así que se recarga la página para reflejar el
+    // avatarUrl persistido y limpiar el preview.
+    await page.reload();
+    await expect(page.getByText('Imágenes del perfil')).toBeVisible({ timeout: 15000 });
+
+    const deleteBtn = avatarSection.getByRole('button', { name: 'Eliminar imagen' });
+    await expect(deleteBtn).toBeVisible({ timeout: 15000 });
+
+    // handleDelete usa confirm() nativo — aceptar el diálogo ANTES de hacer clic.
+    page.once('dialog', (dialog) => dialog.accept());
+    await deleteBtn.click();
+
+    await expect(page.getByText('Avatar eliminado.')).toBeVisible({ timeout: 15000 });
+    await expect(deleteBtn).toBeHidden({ timeout: 15000 });
+  });
+
   test('should display own dashboard with projects', async ({ page }) => {
     await injectAuth(page, authToken);
     await page.goto('/dashboard');


### PR DESCRIPTION
## Contexto (SDD avatar-delete, P3)

Contraparte frontend del PR de backend Jvbass/incubadora-back#26. La funcionalidad de borrado de avatar ya estaba implementada end-to-end; este PR agrega la cobertura E2E que faltaba. Solo tests, sin cambios de codigo de producto.

## Resumen

- Nuevo test `should upload and delete avatar image` en `e2e/profile.spec.ts`: sube un PNG minimo via el componente ImageUpload (upload real contra backend + Cloudinary), verifica el toast de exito, acepta el `confirm()` nativo y borra el avatar, verificando toast y desaparicion del boton "Eliminar imagen".
- Sigue el patron existente del spec: `apiRegisterAndLogin` en `beforeAll` + `injectAuth` por test, selectores semanticos, textos en espanol verificados contra el codigo fuente.
- El test restaura el estado inicial (usuario sin avatar), sin contaminar los demas tests del bloque.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `e2e/profile.spec.ts` | Test nuevo de flujo upload + delete de avatar |

## Test plan

- [x] `pnpm test:e2e e2e/profile.spec.ts` — 6/6 en verde contra el stack completo (backend + MySQL + Cloudinary reales)
- [x] `tsc --noEmit` y `eslint` sin errores
- [x] Revision de contexto fresco pre-push: APPROVE (strings de UI verificados, orden dialog-handler/click correcto, sin riesgos de flakiness)

## Notas

- El test hace un `page.reload()` despues del upload porque `ImageUpload.tsx` nunca limpia el estado `preview` tras un upload exitoso, y el boton "Eliminar imagen" requiere `!preview` — el boton no aparece hasta recargar. Es un bug menor de UX preexistente, documentado para un follow-up; el test cubre el comportamiento actual real.
- Sugerencia de robustez para el futuro (no bloqueante): agregar un `data-testid` a `ImageUpload` para evitar el selector por clase `space-y-2` + filtro de texto.