### PR TITLE
feat(kudo): let receiver toggle kudo visibility on profile and dashboard

### DIFF
--- a/e2e/kudos.spec.ts
+++ b/e2e/kudos.spec.ts
@@ -44,8 +44,9 @@ test.describe('Kudos', () => {
 
     // Establecer el slug y hacer público el perfil de user1
     // para que sea accesible en /portfolio/:slug
+    // Nota: el endpoint real es PUT /api/profile (no /api/me/profile).
     const knownSlug = `${PREFIX}-recipient-e2e`;
-    await request.put(`${BASE_API_URL}/me/profile`, {
+    const profileUpdateResponse = await request.put(`${BASE_API_URL}/profile`, {
       data: {
         headline: 'E2E Test User',
         slug: knownSlug,
@@ -59,6 +60,10 @@ test.describe('Kudos', () => {
       },
       headers: { Authorization: `Bearer ${token1}` },
     });
+    if (!profileUpdateResponse.ok()) {
+      const body = await profileUpdateResponse.text();
+      throw new Error(`Profile setup failed (${profileUpdateResponse.status()}): ${body}`);
+    }
     user1Slug = knownSlug;
   });
 
@@ -116,7 +121,7 @@ test.describe('Kudos', () => {
     expect(hasKudos || isPrivate || notFound || true).toBeTruthy();
   });
 
-  test('should not allow giving a kudo to yourself', async ({ page, request }) => {
+  test('should not allow giving a kudo to yourself', async ({ request }) => {
     // Intentar dar kudo a sí mismo via API (debe fallar)
     const response = await request.post(`${BASE_API_URL}/kudos`, {
       data: {
@@ -128,5 +133,66 @@ test.describe('Kudos', () => {
 
     // RN-06: debería retornar 4xx (409 según la documentación)
     expect(response.status()).toBeGreaterThanOrEqual(400);
+  });
+
+  test('should let the receiver publish and unpublish a received kudo, reflected on the public portfolio', async ({
+    page,
+    request,
+  }) => {
+    const uniqueMessage = `Kudo toggle visibility test ${Date.now()}`;
+
+    // Sembrar el kudo via API (nace privado por defecto).
+    // Nota: el backend espera `receiverSlug` (KudoRequestDto), no `recipientUsername`.
+    const createResponse = await request.post(`${BASE_API_URL}/kudos`, {
+      data: {
+        receiverSlug: user1Slug,
+        message: uniqueMessage,
+      },
+      headers: { Authorization: `Bearer ${token2}` },
+    });
+    expect(createResponse.ok()).toBeTruthy();
+    const createdKudo: { id: number } = await createResponse.json();
+    const kudoId = createdKudo.id;
+
+    const getReceiverKudo = async () => {
+      const response = await request.get(`${BASE_API_URL}/profile`, {
+        headers: { Authorization: `Bearer ${token1}` },
+      });
+      const body: { kudosReceived: { id: number; isPublic: boolean }[] } = await response.json();
+      return body.kudosReceived.find((k) => k.id === kudoId);
+    };
+
+    // El receptor entra a su propio perfil y ve el kudo recién creado como privado.
+    await injectAuth(page, token1);
+    await page.goto('/profile');
+    const kudoCard = page.getByTestId(`kudo-${kudoId}`);
+    await expect(kudoCard).toBeVisible({ timeout: 10000 });
+    await expect(kudoCard.getByTestId(`kudo-visibility-${kudoId}`)).toHaveText('Privado');
+
+    // Publicar el kudo desde la UI.
+    await kudoCard.getByRole('button', { name: 'Publicar' }).click();
+    await expect(kudoCard.getByTestId(`kudo-visibility-${kudoId}`)).toHaveText('Público', {
+      timeout: 10000,
+    });
+    expect((await getReceiverKudo())?.isPublic).toBe(true);
+
+    // El kudo publicado debe aparecer en el portfolio público del receptor.
+    await page.goto(`/portfolio/${user1Slug}`);
+    await expect(page.getByText(uniqueMessage)).toBeVisible({ timeout: 10000 });
+
+    // Despublicar el kudo desde el propio perfil.
+    await page.goto('/profile');
+    const kudoCardAfterPublish = page.getByTestId(`kudo-${kudoId}`);
+    await expect(kudoCardAfterPublish).toBeVisible({ timeout: 10000 });
+    await kudoCardAfterPublish.getByRole('button', { name: 'Hacer privado' }).click();
+    await expect(kudoCardAfterPublish.getByTestId(`kudo-visibility-${kudoId}`)).toHaveText(
+      'Privado',
+      { timeout: 10000 }
+    );
+    expect((await getReceiverKudo())?.isPublic).toBe(false);
+
+    // Ya no debe aparecer en el portfolio público.
+    await page.goto(`/portfolio/${user1Slug}`);
+    await expect(page.getByText(uniqueMessage)).not.toBeVisible();
   });
 });

--- a/e2e/kudos.spec.ts
+++ b/e2e/kudos.spec.ts
@@ -195,4 +195,88 @@ test.describe('Kudos', () => {
     await page.goto(`/portfolio/${user1Slug}`);
     await expect(page.getByText(uniqueMessage)).not.toBeVisible();
   });
+
+  test('should let the receiver publish a kudo from the dashboard kudos tab and see it reflected on /profile via client-side navigation', async ({
+    page,
+    request,
+  }) => {
+    const uniqueMessage = `Kudo dashboard toggle test ${Date.now()}`;
+
+    // Sembrar el kudo via API (nace privado por defecto).
+    const createResponse = await request.post(`${BASE_API_URL}/kudos`, {
+      data: {
+        receiverSlug: user1Slug,
+        message: uniqueMessage,
+      },
+      headers: { Authorization: `Bearer ${token2}` },
+    });
+    expect(createResponse.ok()).toBeTruthy();
+    const createdKudo: { id: number } = await createResponse.json();
+    const kudoId = createdKudo.id;
+
+    const getReceiverKudo = async () => {
+      const response = await request.get(`${BASE_API_URL}/profile`, {
+        headers: { Authorization: `Bearer ${token1}` },
+      });
+      const body: { kudosReceived: { id: number; isPublic: boolean }[] } = await response.json();
+      return body.kudosReceived.find((k) => k.id === kudoId);
+    };
+
+    // Único page.goto() del test: establece la sesión y cachea /profile
+    // (queryKey ["userProfile"], staleTime 1h) mostrando el kudo privado.
+    await injectAuth(page, token1);
+    await page.goto('/profile');
+    const kudoCardOnProfile = page.getByTestId(`kudo-${kudoId}`);
+    await expect(kudoCardOnProfile).toBeVisible({ timeout: 10000 });
+    await expect(kudoCardOnProfile.getByTestId(`kudo-visibility-${kudoId}`)).toHaveText('Privado');
+
+    // Navegación 100% cliente (dropdown del Navbar, contrato E2E
+    // data-testid="user-menu-trigger" + link "Panel") hacia /dashboard.
+    // Sin page.goto: la SPA no se reinicia y el queryClient conserva el
+    // caché recién poblado de ["userProfile"].
+    await page.getByTestId('user-menu-trigger').click();
+    await page.getByRole('link', { name: 'Panel' }).click();
+    await expect(page).toHaveURL(/\/dashboard$/);
+
+    await page.getByRole('button', { name: 'Kudos' }).click();
+    const kudoRowOnDashboard = page.getByTestId(`kudo-${kudoId}`);
+    await expect(kudoRowOnDashboard).toBeVisible({ timeout: 10000 });
+    await expect(
+      kudoRowOnDashboard.getByTestId(`kudo-visibility-${kudoId}`)
+    ).toHaveText('Privado');
+
+    // Publicar desde la pestaña Kudos del dashboard (cachea bajo ["userData"]).
+    await kudoRowOnDashboard.getByRole('button', { name: 'Publicar' }).click();
+    await expect(
+      kudoRowOnDashboard.getByTestId(`kudo-visibility-${kudoId}`)
+    ).toHaveText('Público', { timeout: 10000 });
+    expect((await getReceiverKudo())?.isPublic).toBe(true);
+
+    // Volver a /profile por navegación cliente (mismo dropdown, link "Mi
+    // Perfil"), SIN goto entre el toggle y esta verificación. Esto ejercita
+    // la invalidación real de ["userProfile"]: esa query ya estaba cacheada
+    // (fresca según su staleTime de 1h) desde el primer goto de este test
+    // mostrando "Privado"; si el toggle del dashboard no invalidara esa
+    // clave, esta vista mostraría el estado obsoleto. Como sí la invalida
+    // (ver DeveloperDashboard.tsx toggleKudoVisibilityMutation), el remount
+    // de ProfilePage refetchea y muestra el estado real del servidor.
+    await page.getByTestId('user-menu-trigger').click();
+    await page.getByRole('link', { name: 'Mi Perfil' }).click();
+    await expect(page).toHaveURL('/profile');
+
+    const kudoCardAfterDashboardToggle = page.getByTestId(`kudo-${kudoId}`);
+    await expect(kudoCardAfterDashboardToggle).toBeVisible({ timeout: 10000 });
+    await expect(
+      kudoCardAfterDashboardToggle.getByTestId(`kudo-visibility-${kudoId}`)
+    ).toHaveText('Público', { timeout: 10000 });
+
+    // Nota / limitación conocida: no existe hoy, para el propio usuario
+    // logueado, un link de navegación cliente hacia su portfolio público
+    // (/portfolio/:slug) — esa ruta solo se linkea desde listados de OTROS
+    // usuarios (seguidos, solicitudes de mentor, mentorías). Por eso la
+    // invalidación de ["portfolio", slug] se cubre en el test anterior
+    // mediante goto (recarga dura), y esta superficie (["userProfile"] /
+    // ["userData"] compartida entre /dashboard y /profile) es la más fuerte
+    // disponible para probar la invalidación real vía navegación cliente.
+  });
 });

--- a/src/api/kudoApi.ts
+++ b/src/api/kudoApi.ts
@@ -8,3 +8,19 @@ export const postKudo = async (kudoData: KudoPost): Promise<KudoResponse> => {
   const { data } = await apiService.post<KudoResponse>("/kudos", kudoData);
   return data;
 };
+
+/**
+ * Publica o despublica un kudo recibido. Solo el receptor puede hacerlo.
+ * `isPublic` se envía como query param (el backend espera `@RequestParam boolean isPublic`).
+ */
+export const toggleKudoVisibility = async (
+  kudoId: number,
+  isPublic: boolean
+): Promise<KudoResponse> => {
+  const { data } = await apiService.patch<KudoResponse>(
+    `/kudos/${kudoId}/toggle-visibility`,
+    null,
+    { params: { isPublic } }
+  );
+  return data;
+};

--- a/src/features/dashboard/pages/DeveloperDashboard.tsx
+++ b/src/features/dashboard/pages/DeveloperDashboard.tsx
@@ -25,6 +25,8 @@ import { useAuthZustand } from "../../../hooks/useAuthZustand";
 import toast from "react-hot-toast";
 import AvatarUsuario from "../../../components/ui/AvatarUsuario";
 import { getFollowedUsers, getFollowedProjects, type FollowedUser } from "../../../api/followApi";
+import { toggleKudoVisibility } from "../../../api/kudoApi";
+import type { AxiosError } from "axios";
 
 type TabKey = "resumen" | "proyectos" | "mentorias" | "feedback" | "kudos" | "social";
 
@@ -146,6 +148,23 @@ const DeveloperDashboard = () => {
     },
     onError: (err: any) =>
       toast.error(err.response?.data?.message || "No se pudo cambiar el estado."),
+  });
+
+  // Publicar/despublicar un kudo recibido desde el dashboard. Mismo payload
+  // de perfil que ProfilePage, pero cacheado bajo la clave "userData" acá:
+  // hay que invalidar AMBAS claves o una de las dos superficies queda obsoleta.
+  const toggleKudoVisibilityMutation = useMutation({
+    mutationFn: ({ kudoId, isPublic }: { kudoId: number; isPublic: boolean }) =>
+      toggleKudoVisibility(kudoId, isPublic),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userData"] });
+      queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+    },
+    onError: (err: AxiosError<{ message?: string }>) => {
+      toast.error(
+        err.response?.data?.message || "No se pudo cambiar la visibilidad del kudo."
+      );
+    },
   });
 
   const archiveMentorshipMutation = useMutation({
@@ -443,9 +462,36 @@ const DeveloperDashboard = () => {
             ) : (
               <ul className="space-y-2 text-sm">
                 {data.kudosReceived.map((k) => (
-                  <li key={k.id} className="border-b border-divider dark:border-border pb-2 last:border-0">
-                    <span className="font-medium">{k.senderUsername}</span>
-                    <span className="text-text-soft dark:text-gray-400"> — {k.message}</span>
+                  <li
+                    key={k.id}
+                    data-testid={`kudo-${k.id}`}
+                    className="flex flex-wrap items-center justify-between gap-2 border-b border-divider dark:border-border pb-2 last:border-0"
+                  >
+                    <div>
+                      <span className="font-medium">{k.senderUsername}</span>
+                      <span className="text-text-soft dark:text-gray-400"> — {k.message}</span>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span
+                        data-testid={`kudo-visibility-${k.id}`}
+                        className="text-xs text-text-soft dark:text-gray-400"
+                      >
+                        {k.isPublic ? "Público" : "Privado"}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          toggleKudoVisibilityMutation.mutate({
+                            kudoId: k.id,
+                            isPublic: !k.isPublic,
+                          })
+                        }
+                        disabled={toggleKudoVisibilityMutation.isPending}
+                        className="text-xs font-medium text-cta-600 border border-cta-600 rounded-full px-3 py-1 hover:bg-cta-600 hover:text-white transition-colors disabled:opacity-50"
+                      >
+                        {k.isPublic ? "Hacer privado" : "Publicar"}
+                      </button>
+                    </div>
                   </li>
                 ))}
               </ul>

--- a/src/features/dashboard/pages/DeveloperDashboard.tsx
+++ b/src/features/dashboard/pages/DeveloperDashboard.tsx
@@ -152,13 +152,19 @@ const DeveloperDashboard = () => {
 
   // Publicar/despublicar un kudo recibido desde el dashboard. Mismo payload
   // de perfil que ProfilePage, pero cacheado bajo la clave "userData" acá:
-  // hay que invalidar AMBAS claves o una de las dos superficies queda obsoleta.
+  // hay que invalidar TODAS las claves que sirven el mismo payload de
+  // perfil (symmetric con ProfilePage), incluida la del portfolio público
+  // (["portfolio", slug]) para que no quede desactualizada.
   const toggleKudoVisibilityMutation = useMutation({
     mutationFn: ({ kudoId, isPublic }: { kudoId: number; isPublic: boolean }) =>
       toggleKudoVisibility(kudoId, isPublic),
     onSuccess: () => {
+      toast.success("Visibilidad del kudo actualizada.");
       queryClient.invalidateQueries({ queryKey: ["userData"] });
       queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+      if (data?.slug) {
+        queryClient.invalidateQueries({ queryKey: ["portfolio", data.slug] });
+      }
     },
     onError: (err: AxiosError<{ message?: string }>) => {
       toast.error(

--- a/src/features/profile/pages/ProfilePage.tsx
+++ b/src/features/profile/pages/ProfilePage.tsx
@@ -1,6 +1,8 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams, useNavigate } from "react-router-dom";
+import type { AxiosError } from "axios";
 import { fetchPublicProfileBySlug, fetchUserProfile } from "../../../api/profileApi";
+import { toggleKudoVisibility } from "../../../api/kudoApi";
 import Loading from "../../../components/ux/Loading";
 import { ProjectCard } from "../../projects/components/ProjectCard";
 import {
@@ -123,6 +125,26 @@ const ProfilePage = () => {
       toast.error("Error al copiar" + err);
     }
   };
+
+  // Publicar/despublicar un kudo recibido (solo el receptor, en su propio perfil).
+  // Sin actualización optimista: el servidor es la fuente de verdad y se
+  // invalidan ambas claves que sirven el mismo payload de perfil.
+  const toggleKudoVisibilityMutation = useMutation({
+    mutationFn: ({ kudoId, isPublic }: { kudoId: number; isPublic: boolean }) =>
+      toggleKudoVisibility(kudoId, isPublic),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+      queryClient.invalidateQueries({ queryKey: ["userData"] });
+      if (slug) {
+        queryClient.invalidateQueries({ queryKey: ["profileBySlug", slug] });
+      }
+    },
+    onError: (err: AxiosError<{ message?: string }>) => {
+      toast.error(
+        err.response?.data?.message || "No se pudo cambiar la visibilidad del kudo."
+      );
+    },
+  });
 
   if (isLoading) {
     return <Loading message="Cargando perfil..." />;
@@ -394,6 +416,7 @@ const ProfilePage = () => {
             {kudosReceived.map((kudo) => (
               <div
                 key={kudo.id}
+                data-testid={`kudo-${kudo.id}`}
                 className="flex justify-between mt-4 p-4 rounded-md dark:text-gray-300 border transition-all duration-200 bg-bg-light dark:bg-bg-dark border-divider dark:border-gray-700 hover:shadow-md hover:border-border dark:hover:border-gray-600"
               >
                 <div className="flex items-start gap-3">
@@ -423,11 +446,29 @@ const ProfilePage = () => {
                     )}
                   </div>
                 </div>
-                {!kudo.isPublic && (
-                  <div className="text-gray-700 dark:text-gray-200 text-sm">
-                    {kudo.isPublic ? "Publico" : "Privado"}
+                <div className="flex flex-col items-end gap-2">
+                  <div
+                    data-testid={`kudo-visibility-${kudo.id}`}
+                    className="text-gray-700 dark:text-gray-200 text-sm"
+                  >
+                    {kudo.isPublic ? "Público" : "Privado"}
                   </div>
-                )}
+                  {isOwnProfile && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        toggleKudoVisibilityMutation.mutate({
+                          kudoId: kudo.id,
+                          isPublic: !kudo.isPublic,
+                        })
+                      }
+                      disabled={toggleKudoVisibilityMutation.isPending}
+                      className="text-xs font-medium text-cta-600 border border-cta-600 rounded-full px-3 py-1 hover:bg-cta-600 hover:text-white transition-colors disabled:opacity-50"
+                    >
+                      {kudo.isPublic ? "Hacer privado" : "Publicar"}
+                    </button>
+                  )}
+                </div>
               </div>
             ))}
 

--- a/src/features/profile/pages/ProfilePage.tsx
+++ b/src/features/profile/pages/ProfilePage.tsx
@@ -128,15 +128,20 @@ const ProfilePage = () => {
 
   // Publicar/despublicar un kudo recibido (solo el receptor, en su propio perfil).
   // Sin actualización optimista: el servidor es la fuente de verdad y se
-  // invalidan ambas claves que sirven el mismo payload de perfil.
+  // invalidan todas las claves que sirven el mismo payload de perfil,
+  // incluida la del portfolio público (["portfolio", slug]) para que un
+  // visitante con esa página ya cacheada no siga viendo el kudo en el
+  // estado de visibilidad anterior al toggle.
   const toggleKudoVisibilityMutation = useMutation({
     mutationFn: ({ kudoId, isPublic }: { kudoId: number; isPublic: boolean }) =>
       toggleKudoVisibility(kudoId, isPublic),
     onSuccess: () => {
+      toast.success("Visibilidad del kudo actualizada.");
       queryClient.invalidateQueries({ queryKey: ["userProfile"] });
       queryClient.invalidateQueries({ queryKey: ["userData"] });
-      if (slug) {
-        queryClient.invalidateQueries({ queryKey: ["profileBySlug", slug] });
+      const ownSlug = ownProfileData?.slug;
+      if (ownSlug) {
+        queryClient.invalidateQueries({ queryKey: ["portfolio", ownSlug] });
       }
     },
     onError: (err: AxiosError<{ message?: string }>) => {


### PR DESCRIPTION
## Contexto (SDD kudos-status-wiring, P3)

PR 2 de 3 (stacked-to-main). El backend ya exponia `PATCH /api/kudos/{id}/toggle-visibility` (solo receptor), pero el frontend no lo usaba: el receptor no tenia forma de aprobar/publicar los kudos recibidos, a pesar de que el modal de envio ya promete ese flujo. PR 1: Jvbass/incubadora-back#27 (regla edit-reset, independiente de este). PR 3 (pendiente): gestion del emisor (editar/borrar).

## Resumen

- `toggleKudoVisibility` en `kudoApi.ts` (`isPublic` como query param, como espera el backend).
- Toggle de visibilidad para el receptor en las dos superficies que muestran kudos recibidos: ProfilePage y la pestana kudos del DeveloperDashboard. Boton con estado pending (sin doble submit), toasts de exito/error consistentes con las demas mutaciones del dashboard.
- Fix del badge de visibilidad muerto en ProfilePage (un condicional que solo podia renderizar "Privado"); ahora muestra el estado real en ambos casos.
- Invalidacion invalidate-and-refetch sobre todas las query keys que sirven el mismo payload de perfil: `["userProfile"]`, `["userData"]` y `["portfolio", <slug propio>]` (la pagina publica, staleTime 20 min). Se elimino una invalidacion de `["profileBySlug"]` que era codigo muerto (la ruta no existe en el router).
- E2E con aserciones reales: toggle desde ProfilePage, toggle desde el dashboard (superficie antes sin cobertura), y una asercion de invalidacion cruzada con navegacion 100% client-side (sin `page.goto()` entre el toggle y la verificacion, que reiniciaria el cache y enmascararia regresiones).
- Fix de dos bugs preexistentes del fixture de `kudos.spec.ts` que estaban ocultos por aserciones `|| true`: endpoint inexistente `PUT /api/me/profile` (real: `PUT /api/profile`) y campo `recipientUsername` (real: `receiverSlug`).

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/api/kudoApi.ts` | `toggleKudoVisibility` (PATCH con query param) |
| `src/features/profile/pages/ProfilePage.tsx` | Toggle + fix del badge + invalidacion completa + toasts |
| `src/features/dashboard/pages/DeveloperDashboard.tsx` | Toggle en pestana kudos + invalidacion completa + toasts |
| `e2e/kudos.spec.ts` | 2 tests nuevos con aserciones reales + fix de fixture |

## Test plan

- [x] `pnpm test:e2e e2e/kudos.spec.ts` — 4 en verde + 1 skip preexistente, contra el stack completo
- [x] `pnpm build` y lint limpios (los 5 errores `no-explicit-any` preexistentes de DeveloperDashboard quedan igual, sin errores nuevos)
- [x] Revision de contexto fresco: CHANGES REQUESTED (gap de invalidacion del portfolio detectado) → corregido en `d10b2fc` → re-verificado APPROVE

## Notas

- Limite documentado en el spec E2E: no existe camino client-side desde un usuario logueado a su propio `/portfolio/:slug`, asi que la invalidacion de esa key se cubre por simetria de codigo y no por asercion de navegacion; el limite quedo comentado en el test en lugar de taparlo con una asercion falsa.
- Los otros dos tests preexistentes del spec conservan el patron laxo anterior — limpieza fuera de alcance de este PR.