### PR TITLE
feat(kudo): sender edit and delete on dashboard sent-kudos list

### DIFF
--- a/e2e/kudos.spec.ts
+++ b/e2e/kudos.spec.ts
@@ -279,4 +279,105 @@ test.describe('Kudos', () => {
     // ["userData"] compartida entre /dashboard y /profile) es la más fuerte
     // disponible para probar la invalidación real vía navegación cliente.
   });
+
+  test('should let the sender edit a published kudo message and reset its visibility to private', async ({
+    page,
+    request,
+  }) => {
+    const originalMessage = `Kudo sender-edit test ${Date.now()}`;
+    const editedMessage = `${originalMessage} (editado)`;
+
+    // Sembrar el kudo (token2 es el emisor, user1/token1 es el receptor).
+    const createResponse = await request.post(`${BASE_API_URL}/kudos`, {
+      data: { receiverSlug: user1Slug, message: originalMessage },
+      headers: { Authorization: `Bearer ${token2}` },
+    });
+    expect(createResponse.ok()).toBeTruthy();
+    const createdKudo: { id: number } = await createResponse.json();
+    const kudoId = createdKudo.id;
+
+    // El receptor lo publica via API para partir de un estado público:
+    // así la aserción de "vuelve a ser privado tras la edición" es real.
+    const publishResponse = await request.patch(
+      `${BASE_API_URL}/kudos/${kudoId}/toggle-visibility?isPublic=true`,
+      { headers: { Authorization: `Bearer ${token1}` } }
+    );
+    expect(publishResponse.ok()).toBeTruthy();
+
+    const getSenderKudo = async () => {
+      const response = await request.get(`${BASE_API_URL}/profile`, {
+        headers: { Authorization: `Bearer ${token2}` },
+      });
+      const body: { kudosGiven: { id: number; isPublic: boolean; message: string }[] } =
+        await response.json();
+      return body.kudosGiven.find((k) => k.id === kudoId);
+    };
+
+    expect((await getSenderKudo())?.isPublic).toBe(true);
+
+    // El emisor entra al dashboard y edita el kudo desde "Kudos realizados".
+    await injectAuth(page, token2);
+    await page.goto('/dashboard');
+    await page.getByRole('button', { name: 'Kudos' }).click();
+
+    const kudoRow = page.getByTestId(`kudo-given-${kudoId}`);
+    await expect(kudoRow).toBeVisible({ timeout: 10000 });
+    await expect(kudoRow.getByText(originalMessage)).toBeVisible();
+
+    await kudoRow.getByTestId(`kudo-edit-${kudoId}`).click();
+    const textarea = page.getByTestId(`kudo-edit-textarea-${kudoId}`);
+    await expect(textarea).toBeVisible();
+    await textarea.fill(editedMessage);
+    await page.getByTestId(`kudo-save-${kudoId}`).click();
+
+    // OJO: `getByText` puede matchear el valor "en vivo" de un <textarea>
+    // montado, así que no sirve como señal de que el guardado ya terminó
+    // (podría matchear el texto tipeado ANTES de que la mutación async
+    // resuelva). La señal confiable de que `onSuccess` ya corrió y la fila
+    // volvió a modo lectura es que el propio textarea deje de existir.
+    await expect(textarea).not.toBeVisible({ timeout: 10000 });
+
+    // Ahora sí, en modo lectura, el mensaje mostrado debe ser el editado.
+    const kudoRowAfterEdit = page.getByTestId(`kudo-given-${kudoId}`);
+    await expect(kudoRowAfterEdit.getByText(editedMessage)).toBeVisible();
+
+    const updatedKudo = await getSenderKudo();
+    expect(updatedKudo?.message).toBe(editedMessage);
+    expect(updatedKudo?.isPublic).toBe(false);
+  });
+
+  test('should let the sender delete a sent kudo after confirming', async ({ page, request }) => {
+    const uniqueMessage = `Kudo sender-delete test ${Date.now()}`;
+
+    const createResponse = await request.post(`${BASE_API_URL}/kudos`, {
+      data: { receiverSlug: user1Slug, message: uniqueMessage },
+      headers: { Authorization: `Bearer ${token2}` },
+    });
+    expect(createResponse.ok()).toBeTruthy();
+    const createdKudo: { id: number } = await createResponse.json();
+    const kudoId = createdKudo.id;
+
+    await injectAuth(page, token2);
+    await page.goto('/dashboard');
+    await page.getByRole('button', { name: 'Kudos' }).click();
+
+    const kudoRow = page.getByTestId(`kudo-given-${kudoId}`);
+    await expect(kudoRow).toBeVisible({ timeout: 10000 });
+
+    // Registrar el manejo del confirm() nativo ANTES de disparar el click
+    // que lo abre; se acepta para que la eliminación continúe.
+    page.once('dialog', (dialog) => dialog.accept());
+    await kudoRow.getByTestId(`kudo-delete-${kudoId}`).click();
+
+    await expect(page.getByTestId(`kudo-given-${kudoId}`)).not.toBeVisible({ timeout: 10000 });
+
+    const getSenderKudo = async () => {
+      const response = await request.get(`${BASE_API_URL}/profile`, {
+        headers: { Authorization: `Bearer ${token2}` },
+      });
+      const body: { kudosGiven: { id: number }[] } = await response.json();
+      return body.kudosGiven.find((k) => k.id === kudoId);
+    };
+    expect(await getSenderKudo()).toBeUndefined();
+  });
 });

--- a/src/api/kudoApi.ts
+++ b/src/api/kudoApi.ts
@@ -24,3 +24,28 @@ export const toggleKudoVisibility = async (
   );
   return data;
 };
+
+/**
+ * Edita el mensaje de un kudo enviado. Solo el emisor puede hacerlo.
+ * El backend espera `@RequestBody String message`: se manda el string
+ * crudo con Content-Type text/plain, no un objeto JSON. Cualquier edición
+ * resetea el kudo a privado en el servidor, sin importar su estado previo.
+ */
+export const updateKudoMessage = async (
+  kudoId: number,
+  message: string
+): Promise<KudoResponse> => {
+  const { data } = await apiService.put<KudoResponse>(
+    `/kudos/${kudoId}`,
+    message,
+    { headers: { "Content-Type": "text/plain" } }
+  );
+  return data;
+};
+
+/**
+ * Elimina un kudo enviado. Solo el emisor puede hacerlo.
+ */
+export const deleteKudo = async (kudoId: number): Promise<void> => {
+  await apiService.delete(`/kudos/${kudoId}`);
+};

--- a/src/features/dashboard/pages/DeveloperDashboard.tsx
+++ b/src/features/dashboard/pages/DeveloperDashboard.tsx
@@ -25,7 +25,7 @@ import { useAuthZustand } from "../../../hooks/useAuthZustand";
 import toast from "react-hot-toast";
 import AvatarUsuario from "../../../components/ui/AvatarUsuario";
 import { getFollowedUsers, getFollowedProjects, type FollowedUser } from "../../../api/followApi";
-import { toggleKudoVisibility } from "../../../api/kudoApi";
+import { toggleKudoVisibility, updateKudoMessage, deleteKudo } from "../../../api/kudoApi";
 import type { AxiosError } from "axios";
 
 type TabKey = "resumen" | "proyectos" | "mentorias" | "feedback" | "kudos" | "social";
@@ -39,6 +39,8 @@ const DeveloperDashboard = () => {
   const [editingMentorshipSlug, setEditingMentorshipSlug] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [tab, setTab] = useState<TabKey>("resumen");
+  const [editingKudoId, setEditingKudoId] = useState<number | null>(null);
+  const [editedKudoMessage, setEditedKudoMessage] = useState("");
 
   const queryClient = useQueryClient();
   const { user } = useAuthZustand();
@@ -172,6 +174,62 @@ const DeveloperDashboard = () => {
       );
     },
   });
+
+  // Editar el mensaje de un kudo enviado. El backend resetea isPublic=false
+  // en cualquier edición, así que solo hace falta invalidar las claves que
+  // sirven la lista "kudos realizados" (["userData"]) y, por simetría con
+  // el resto de mutaciones de este archivo, ["userProfile"].
+  const updateKudoMessageMutation = useMutation({
+    mutationFn: ({ kudoId, message }: { kudoId: number; message: string }) =>
+      updateKudoMessage(kudoId, message),
+    onSuccess: () => {
+      toast.success("Kudo actualizado. El receptor deberá volver a publicarlo.");
+      queryClient.invalidateQueries({ queryKey: ["userData"] });
+      queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+      setEditingKudoId(null);
+      setEditedKudoMessage("");
+    },
+    onError: (err: AxiosError<{ message?: string }>) => {
+      toast.error(err.response?.data?.message || "No se pudo editar el kudo.");
+    },
+  });
+
+  // Eliminar un kudo enviado. Solo afecta la propia lista "kudos
+  // realizados" del emisor (["userData"]); no existe un slug del receptor
+  // en KudoResponse para invalidar su portfolio, y el receptor refresca
+  // su propia caché en su próximo fetch.
+  const deleteKudoMutation = useMutation({
+    mutationFn: (kudoId: number) => deleteKudo(kudoId),
+    onSuccess: () => {
+      toast.success("Kudo eliminado.");
+      queryClient.invalidateQueries({ queryKey: ["userData"] });
+    },
+    onError: (err: AxiosError<{ message?: string }>) => {
+      toast.error(err.response?.data?.message || "No se pudo eliminar el kudo.");
+    },
+  });
+
+  const handleStartEditKudo = (kudoId: number, currentMessage: string) => {
+    setEditingKudoId(kudoId);
+    setEditedKudoMessage(currentMessage);
+  };
+
+  const handleCancelEditKudo = () => {
+    setEditingKudoId(null);
+    setEditedKudoMessage("");
+  };
+
+  const handleSaveEditKudo = (kudoId: number) => {
+    const trimmedMessage = editedKudoMessage.trim();
+    if (!trimmedMessage) return;
+    updateKudoMessageMutation.mutate({ kudoId, message: trimmedMessage });
+  };
+
+  const handleDeleteKudo = (kudoId: number) => {
+    if (window.confirm("¿Eliminar este kudo? Esta acción no se puede deshacer.")) {
+      deleteKudoMutation.mutate(kudoId);
+    }
+  };
 
   const archiveMentorshipMutation = useMutation({
     mutationFn: archiveMentorship,
@@ -511,12 +569,81 @@ const DeveloperDashboard = () => {
               <p className="text-sm text-text-soft dark:text-gray-400">Todavía no diste kudos.</p>
             ) : (
               <ul className="space-y-2 text-sm">
-                {data.kudosGiven.map((k) => (
-                  <li key={k.id} className="border-b border-divider dark:border-border pb-2 last:border-0">
-                    Para <span className="font-medium">{k.receiverUsername}</span>
-                    <span className="text-text-soft dark:text-gray-400"> — {k.message}</span>
-                  </li>
-                ))}
+                {data.kudosGiven.map((k) =>
+                  editingKudoId === k.id ? (
+                    <li
+                      key={k.id}
+                      data-testid={`kudo-given-${k.id}`}
+                      className="flex flex-col gap-2 border-b border-divider dark:border-border pb-2 last:border-0"
+                    >
+                      <p className="text-xs text-text-soft dark:text-gray-400">
+                        Para <span className="font-medium">{k.receiverUsername}</span>
+                      </p>
+                      <textarea
+                        data-testid={`kudo-edit-textarea-${k.id}`}
+                        value={editedKudoMessage}
+                        onChange={(e) => setEditedKudoMessage(e.target.value)}
+                        rows={2}
+                        className="w-full text-sm rounded-md border border-divider dark:border-border bg-bg-light dark:bg-bg-dark p-2 text-text-main dark:text-text-light"
+                      />
+                      <p className="text-xs text-amber-600 dark:text-amber-400">
+                        Al guardar, este kudo volverá a ser privado y el receptor deberá
+                        aprobarlo de nuevo para que sea público.
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          data-testid={`kudo-save-${k.id}`}
+                          onClick={() => handleSaveEditKudo(k.id)}
+                          disabled={
+                            updateKudoMessageMutation.isPending || !editedKudoMessage.trim()
+                          }
+                          className="text-xs font-medium text-white bg-cta-600 rounded-full px-3 py-1 hover:bg-cta-700 transition-colors disabled:opacity-50"
+                        >
+                          Guardar
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleCancelEditKudo}
+                          disabled={updateKudoMessageMutation.isPending}
+                          className="text-xs font-medium text-text-soft dark:text-gray-400 border border-divider dark:border-border rounded-full px-3 py-1 hover:bg-bg-light dark:hover:bg-bg-dark transition-colors disabled:opacity-50"
+                        >
+                          Cancelar
+                        </button>
+                      </div>
+                    </li>
+                  ) : (
+                    <li
+                      key={k.id}
+                      data-testid={`kudo-given-${k.id}`}
+                      className="flex flex-wrap items-center justify-between gap-2 border-b border-divider dark:border-border pb-2 last:border-0"
+                    >
+                      <div>
+                        Para <span className="font-medium">{k.receiverUsername}</span>
+                        <span className="text-text-soft dark:text-gray-400"> — {k.message}</span>
+                      </div>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <button
+                          type="button"
+                          data-testid={`kudo-edit-${k.id}`}
+                          onClick={() => handleStartEditKudo(k.id, k.message)}
+                          className="text-xs font-medium text-cta-600 border border-cta-600 rounded-full px-3 py-1 hover:bg-cta-600 hover:text-white transition-colors"
+                        >
+                          Editar
+                        </button>
+                        <button
+                          type="button"
+                          data-testid={`kudo-delete-${k.id}`}
+                          onClick={() => handleDeleteKudo(k.id)}
+                          disabled={deleteKudoMutation.isPending}
+                          className="text-xs font-medium text-red-600 border border-red-600 rounded-full px-3 py-1 hover:bg-red-600 hover:text-white transition-colors disabled:opacity-50"
+                        >
+                          Eliminar
+                        </button>
+                      </div>
+                    </li>
+                  )
+                )}
               </ul>
             )}
           </section>

--- a/src/features/dashboard/pages/DeveloperDashboard.tsx
+++ b/src/features/dashboard/pages/DeveloperDashboard.tsx
@@ -584,6 +584,7 @@ const DeveloperDashboard = () => {
                         value={editedKudoMessage}
                         onChange={(e) => setEditedKudoMessage(e.target.value)}
                         rows={2}
+                        maxLength={500}
                         className="w-full text-sm rounded-md border border-divider dark:border-border bg-bg-light dark:bg-bg-dark p-2 text-text-main dark:text-text-light"
                       />
                       <p className="text-xs text-amber-600 dark:text-amber-400">


### PR DESCRIPTION
## Contexto (SDD kudos-status-wiring, P3)

PR 3 de 3 (stacked-to-main, final de la cadena). PR 1: Jvbass/incubadora-back#27 (regla edit-reset, mergeado). PR 2: #22 (toggle del receptor, mergeado). Este PR cierra el gap restante: el emisor no tenia forma de editar ni borrar sus kudos enviados, a pesar de que los endpoints existen hace tiempo.

## Resumen

- `updateKudoMessage` y `deleteKudo` en `kudoApi.ts`. El update envia el body como string crudo con `Content-Type: text/plain` (el backend recibe `@RequestBody String`, no JSON).
- Edicion inline en la lista "Kudos realizados" del dashboard, con advertencia visible ANTES de guardar: editar resetea el kudo a privado y el receptor debe re-aprobarlo (regla del PR 1, ya en main).
- Borrado con `window.confirm` nativo (consistente con el resto de la app), estados pending sin doble submit, toasts de exito/error segun el patron del dashboard.
- Invalidacion: `["userData"]` en ambas mutaciones (la lista de enviados). Verificado que ProfilePage/PortfolioPage solo renderizan kudos recibidos, asi que no requieren invalidacion por cambios en enviados. Limitacion aceptada por diseno: `KudoResponse` no expone `receiverSlug`, no se puede invalidar el cache del portfolio del receptor desde el emisor.
- `maxLength={500}` en el textarea de edicion como defensa: el backend no valida el update (gap preexistente documentado), a diferencia del create que exige `@NotBlank` + `@Size(max=500)`.
- 2 tests E2E nuevos con aserciones reales contra el estado del servidor: editar un kudo publicado → mensaje actualizado Y vuelve a privado; borrar con confirmacion → desaparece.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/api/kudoApi.ts` | `updateKudoMessage` (PUT text/plain) y `deleteKudo` |
| `src/features/dashboard/pages/DeveloperDashboard.tsx` | Edicion inline + borrado en "Kudos realizados" |
| `e2e/kudos.spec.ts` | 2 tests nuevos (edit-resets-visibility, delete) |

## Test plan

- [x] `pnpm test:e2e e2e/kudos.spec.ts` en verde contra el stack reconstruido con la regla edit-reset del backend
- [x] `pnpm build` y lint limpios (sin errores nuevos)
- [x] Revision de contexto fresco: APPROVE; la unica sugerencia (tope de caracteres en el textarea) quedo aplicada en `e34a28f`

## Follow-ups documentados (fuera de alcance)

- Backend: `updateKudo` sin validacion `@NotBlank`/`@Size(max=500)` — el tope del frontend es defensa de UX, no un guard real.
- Backend: mensajes de kudo sin pasar por `TextSanitizer` (ni create ni update).