### PR TITLE
feat(profile): add /complete-profile route, page shell and dashboard cache fix

### DIFF
--- a/src/features/profile/pages/CompleteProfilePage.tsx
+++ b/src/features/profile/pages/CompleteProfilePage.tsx
@@ -1,0 +1,100 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchUserProfile } from "../../../api/profileApi";
+import Loading from "../../../components/ux/Loading";
+import ImageUpload from "../../../components/ui/ImageUpload";
+import toast from "react-hot-toast";
+
+// Página de onboarding de perfil (profile-wizard SDD, WU1): aloja la sección
+// persistente de avatar/imagen de banner (D8) y, a partir de WU2, el
+// ProfileWizard de 4 pasos. Espeja el layout de imágenes de EditProfilePage.
+const CompleteProfilePage = () => {
+  const queryClient = useQueryClient();
+
+  const { data: profileData, isLoading: isLoadingProfile } = useQuery({
+    queryKey: ["userProfile"],
+    queryFn: fetchUserProfile,
+    staleTime: Infinity, // No necesita re-fetch mientras el usuario completa el wizard
+  });
+
+  // Invalida ambas claves de caché (D2): "userProfile" (perfil propio,
+  // /settings, Navbar) y "userData" (dashboard). Evita que el dashboard
+  // quede mostrando un avatar/banner desactualizado tras subir uno acá.
+  const invalidateProfileCaches = () => {
+    queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+    queryClient.invalidateQueries({ queryKey: ["userData"] });
+  };
+
+  const handleAvatarUpload = () => {
+    toast.success("Avatar actualizado correctamente.");
+    invalidateProfileCaches();
+  };
+
+  const handleAvatarDelete = () => {
+    toast.success("Avatar eliminado.");
+    invalidateProfileCaches();
+  };
+
+  const handleBioImageUpload = () => {
+    toast.success("Imagen de banner actualizada correctamente.");
+    invalidateProfileCaches();
+  };
+
+  const handleBioImageDelete = () => {
+    toast.success("Imagen de banner eliminada.");
+    invalidateProfileCaches();
+  };
+
+  if (isLoadingProfile) {
+    return <Loading message="Cargando tu perfil..." />;
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 sm:p-6 lg:p-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-text-main dark:text-text-light">
+          Completa tu perfil
+        </h1>
+        <p className="mt-1 text-sm text-text-soft dark:text-gray-400">
+          Sumá tu foto, tu stack y tu trayectoria para que el resto de la
+          comunidad te conozca mejor. Podés omitir este paso en cualquier
+          momento.
+        </p>
+      </div>
+
+      {/* Imágenes del perfil (D8): se guardan de inmediato, fuera del
+          wizard y sin verse afectadas por omitirlo o abandonarlo. */}
+      <div className="p-6 bg-bg-light dark:bg-bg-dark text-text-main dark:text-text-light rounded-lg shadow-md border border-divider dark:border-border space-y-6">
+        <h2 className="text-xl font-bold text-text-main dark:text-text-light">
+          Imágenes del perfil
+        </h2>
+        <div data-testid="complete-profile-avatar-upload">
+          <ImageUpload
+            label="Avatar"
+            aspectHint="1:1, 400×400"
+            currentImageUrl={profileData?.avatarUrl}
+            endpoint="/profile/avatar"
+            deleteEndpoint="/profile/avatar"
+            onUploadSuccess={handleAvatarUpload}
+            onDeleteSuccess={handleAvatarDelete}
+          />
+        </div>
+        <div data-testid="complete-profile-bio-image-upload">
+          <ImageUpload
+            label="Imagen de banner"
+            aspectHint="3:1, 1200×400"
+            currentImageUrl={profileData?.bioImageUrl}
+            endpoint="/profile/bio-image"
+            deleteEndpoint="/profile/bio-image"
+            onUploadSuccess={handleBioImageUpload}
+            onDeleteSuccess={handleBioImageDelete}
+          />
+        </div>
+      </div>
+
+      {/* TODO (WU2 — profile-wizard): montar <ProfileWizard profile={profileData} />
+          acá debajo, reemplazando este placeholder. */}
+    </div>
+  );
+};
+
+export default CompleteProfilePage;

--- a/src/features/profile/pages/EditProfilePage.tsx
+++ b/src/features/profile/pages/EditProfilePage.tsx
@@ -150,8 +150,13 @@ const EditProfilePage = () => {
     return <Loading message="Cargando formulario de edición..." />;
   }
 
-  const invalidateProfile = () =>
+  // D2/D8 (profile-wizard SDD): invalida ambas claves de caché del perfil —
+  // "userProfile" (esta página, /profile, Navbar) y "userData" (dashboard) —
+  // para que el dashboard no quede mostrando un avatar/banner desactualizado.
+  const invalidateProfile = () => {
     queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+    queryClient.invalidateQueries({ queryKey: ["userData"] });
+  };
 
   const handleAvatarUpload = (_urls: ImageUploadResponse) => {
     toast.success("Avatar actualizado correctamente.");

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -23,6 +23,7 @@ const EditProjectPage = lazy(routeImports.editProject);
 const ProjectDetailPage = lazy(routeImports.projectDetail);
 const ProfilePage = lazy(routeImports.profile);
 const EditProfilePage = lazy(routeImports.editProfile);
+const CompleteProfilePage = lazy(routeImports.completeProfile);
 const PortfolioPage = lazy(routeImports.portfolio);
 const AdminDashboard = lazy(routeImports.adminDashboard);
 const CreateMentorshipPage = lazy(routeImports.createMentorship);
@@ -114,6 +115,10 @@ const AppRouter = () => {
           {/* Compartidas: cualquier usuario autenticado (sin restricción de rol) */}
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/settings" element={<EditProfilePage />} />
+          {/* Wizard de onboarding de perfil (profile-wizard SDD): cualquier
+              usuario autenticado puede completar su propio perfil, sin
+              restricción de rol. */}
+          <Route path="/complete-profile" element={<CompleteProfilePage />} />
 
           {/* DEV · MENTOR · ADMINISTRATOR */}
           <Route

--- a/src/router/routeImports.ts
+++ b/src/router/routeImports.ts
@@ -15,6 +15,8 @@ export const routeImports = {
   projectDetail: () => import("../features/projects/pages/ProjectDetailPage"),
   profile: () => import("../features/profile/pages/ProfilePage"),
   editProfile: () => import("../features/profile/pages/EditProfilePage"),
+  completeProfile: () =>
+    import("../features/profile/pages/CompleteProfilePage"),
   portfolio: () => import("../features/profile/pages/PortfolioPage"),
   adminDashboard: () => import("../features/admin/pages/AdminDashboard"),
   createMentorship: () =>


### PR DESCRIPTION
## Contexto (SDD profile-wizard, P3)

PR 1 de 4 (stacked-to-main). Fundación del wizard de onboarding de perfil: ruta y shell de la página, sin lógica de pasos todavía. Próximos PRs: 2) ProfileWizard core (4 pasos + guardado), 3) banner de onboarding en el dashboard, 4) spec E2E aditivo.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/router/routeImports.ts` | Import lazy de `CompleteProfilePage` |
| `src/router/index.tsx` | Ruta `/complete-profile` bajo `ProtectedRoute` + `AuthenticatedLayout`, sin gate de rol |
| `src/features/profile/pages/CompleteProfilePage.tsx` | Nueva página shell con sección persistente de avatar/bio-image (reutiliza `ImageUpload` sin cambios, guardado inmediato como hoy); punto de montaje del wizard marcado para el PR 2 |
| `src/features/profile/pages/EditProfilePage.tsx` | Fix: la invalidación de caché tras subir avatar/bio-image ahora cubre `["userProfile"]` y `["userData"]` — antes el dashboard quedaba con datos viejos |

## Verificación

- `pnpm build` OK (chunk lazy propio para la página nueva)
- `pnpm lint`: 32 errores, idéntico a la línea base de main (cero nuevos)
- `pnpm test:e2e e2e/profile.spec.ts`: 6/6 verdes (no-regresión de /settings y perfil)
- Verificación manual de `/complete-profile` contra backend vivo: render y guardado inmediato de avatar OK
- Revisión adversarial con contexto fresco: APROBADO, cero findings bloqueantes

🤖 Generated with [Claude Code](https://claude.com/claude-code)