### PR TITLE
feat(profile): add first-run onboarding banner for profile completion

### DIFF
--- a/src/features/dashboard/pages/DeveloperDashboard.tsx
+++ b/src/features/dashboard/pages/DeveloperDashboard.tsx
@@ -22,6 +22,7 @@ import ProjectForm from "../../projects/components/ProjectForm";
 import ProjectDetailPage from "../../projects/pages/ProjectDetailPage";
 import { Button } from "../../../components/button/RoundedButton";
 import { useAuthZustand } from "../../../hooks/useAuthZustand";
+import ProfileCompletionBanner from "../../profile/components/onboarding/ProfileCompletionBanner";
 import toast from "react-hot-toast";
 import AvatarUsuario from "../../../components/ui/AvatarUsuario";
 import { getFollowedUsers, getFollowedProjects, type FollowedUser } from "../../../api/followApi";
@@ -359,6 +360,9 @@ const DeveloperDashboard = () => {
           </Link>
         </div>
       </div>
+
+      {/* ── Onboarding banner (profile-wizard SDD, WU3, R1) ────────────── */}
+      <ProfileCompletionBanner username={user?.username} />
 
       {/* ── Tabs (F-14 / F-16) ─────────────────────────────────────────── */}
       <div className="flex gap-1 border-b border-divider dark:border-border overflow-x-auto">

--- a/src/features/profile/components/ProfileWizard.tsx
+++ b/src/features/profile/components/ProfileWizard.tsx
@@ -13,6 +13,8 @@ import { updateUserProfile } from "../../../api/profileApi";
 import { fetchTechnologies } from "../../../api/projectApi";
 import MultiSelect from "../../projects/components/MultiSelect";
 import { buildUpdateRequest } from "../hooks/useInlineProfileEdit";
+import { useOnboardingBanner } from "../hooks/useOnboardingBanner";
+import { useAuthZustand } from "../../../hooks/useAuthZustand";
 import type {
   ProfileResponse,
   ProfileUpdateRequest,
@@ -60,6 +62,11 @@ const ProfileWizard = ({ profile }: ProfileWizardProps) => {
   // R5: guarda sincrónica contra doble submit (un doble click real dispara
   // dos eventos "submit" antes de que el re-render con `disabled` aplique).
   const hasSubmittedRef = useRef(false);
+
+  // T3.3: el marcador de onboarding se setea a "completed" al guardar y al
+  // equivalente de "dismissed" al omitir (useOnboardingBanner, D3).
+  const { user } = useAuthZustand();
+  const { dismiss, markCompleted } = useOnboardingBanner(user?.username);
 
   const { data: technologies, isLoading: isLoadingTechs } = useQuery({
     queryKey: ["technologies"],
@@ -135,6 +142,7 @@ const ProfileWizard = ({ profile }: ProfileWizardProps) => {
       queryClient.setQueryData(["userData"], updated);
       queryClient.invalidateQueries({ queryKey: ["profileBySlug"] });
       queryClient.invalidateQueries({ queryKey: ["portfolio"] });
+      markCompleted();
       toast.success("Perfil actualizado");
       navigate("/dashboard");
     },
@@ -158,9 +166,10 @@ const ProfileWizard = ({ profile }: ProfileWizardProps) => {
 
   const goBack = () => setStep((s) => Math.max(s - 1, 0));
 
-  // R4: omitir no dispara mutate() nunca; el marcador de onboarding se
-  // conecta en WU3 (T3.3) una vez exista useOnboardingBanner().
+  // R4: omitir no dispara mutate() nunca; solo setea el marcador de
+  // onboarding (equivalente a "dismissed", T3.3) y navega.
   const handleSkip = () => {
+    dismiss();
     navigate("/dashboard");
   };
 

--- a/src/features/profile/components/onboarding/ProfileCompletionBanner.tsx
+++ b/src/features/profile/components/onboarding/ProfileCompletionBanner.tsx
@@ -1,0 +1,53 @@
+import { Link } from "react-router-dom";
+import { Sparkles } from "lucide-react";
+import { useOnboardingBanner } from "../../hooks/useOnboardingBanner";
+
+interface ProfileCompletionBannerProps {
+  username?: string;
+}
+
+// Banner de onboarding del dashboard (profile-wizard SDD, WU3, R1).
+// Autogestionado: no renderiza nada una vez que el usuario lo descarta,
+// completa el wizard, o ya tiene un marcador de una sesión anterior.
+const ProfileCompletionBanner = ({ username }: ProfileCompletionBannerProps) => {
+  const { shouldShow, dismiss } = useOnboardingBanner(username);
+
+  if (!shouldShow) return null;
+
+  return (
+    <div
+      data-testid="profile-completion-banner"
+      className="p-5 rounded-lg border bg-bg-light dark:bg-bg-dark border-cta-300 dark:border-cta-700 flex flex-col sm:flex-row sm:items-center gap-4"
+    >
+      <Sparkles size={24} className="text-cta-600 dark:text-cta-300 shrink-0" />
+      <div className="flex-1">
+        <h3 className="font-semibold text-text-main dark:text-text-light">
+          Completa tu perfil
+        </h3>
+        <p className="text-sm text-text-soft dark:text-gray-400">
+          Agrega tu experiencia, stack y redes sociales para que el resto de la
+          comunidad te conozca mejor.
+        </p>
+      </div>
+      <div className="flex items-center gap-4 shrink-0">
+        <button
+          type="button"
+          onClick={dismiss}
+          data-testid="profile-completion-banner-dismiss"
+          className="text-sm font-medium text-text-soft hover:text-text-main dark:hover:text-text-light hover:underline cursor-pointer"
+        >
+          Ahora no
+        </button>
+        <Link
+          to="/complete-profile"
+          data-testid="profile-completion-banner-primary"
+          className="flex items-center gap-1 text-sm font-semibold rounded-md py-1.5 px-3 border border-cta-600 text-cta-600 hover:bg-cta-600 hover:text-white transition-colors dark:border-cta-300 dark:text-cta-300"
+        >
+          Empezar
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCompletionBanner;

--- a/src/features/profile/hooks/useOnboardingBanner.ts
+++ b/src/features/profile/hooks/useOnboardingBanner.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from "react";
+
+const ONBOARDING_KEY_PREFIX = "incubadora:onboarding:profile-wizard:";
+
+type OnboardingMarker = "completed" | "dismissed";
+
+const getMarkerKey = (username: string) => `${ONBOARDING_KEY_PREFIX}${username}`;
+
+const readMarker = (username?: string): OnboardingMarker | null => {
+  if (!username) return null;
+  return localStorage.getItem(getMarkerKey(username)) as OnboardingMarker | null;
+};
+
+// Gate de onboarding del perfil (profile-wizard SDD, WU3/D3). Un marcador en
+// localStorage, claveado por usuario, decide si se muestra el banner de
+// "completa tu perfil" en el dashboard. La ausencia de marcador significa
+// "nunca visto" -> se muestra; "dismissed" o "completed" lo ocultan para
+// siempre (por navegador + usuario). Es una limitación aceptada (D3): no es
+// server-backed, es solo un nudge, el wizard siempre se puede omitir.
+export const useOnboardingBanner = (username?: string) => {
+  const [marker, setMarker] = useState<OnboardingMarker | null>(() =>
+    readMarker(username)
+  );
+
+  const setAndPersist = useCallback(
+    (value: OnboardingMarker) => {
+      if (!username) return;
+      localStorage.setItem(getMarkerKey(username), value);
+      setMarker(value);
+    },
+    [username]
+  );
+
+  const dismiss = useCallback(() => setAndPersist("dismissed"), [setAndPersist]);
+  const markCompleted = useCallback(() => setAndPersist("completed"), [setAndPersist]);
+
+  return {
+    // false mientras `username` no esté resuelto (evita un flash antes de
+    // que la autenticación resuelva) y false una vez que exista cualquier
+    // marcador (dismissed o completed).
+    shouldShow: !!username && marker === null,
+    dismiss,
+    markCompleted,
+  };
+};


### PR DESCRIPTION
## Contexto (SDD profile-wizard, P3)

PR 3 de 4 (stacked-to-main). El punto de entrada del wizard: banner de onboarding en el dashboard para usuarios que aún no lo vieron. Falta solo el PR 4 (spec E2E aditivo dedicado).

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/features/profile/hooks/useOnboardingBanner.ts` | Nuevo hook: gate por `localStorage` con key por usuario (`incubadora:onboarding:profile-wizard:${username}`), estados dismissed/skipped/completed |
| `src/features/profile/components/onboarding/ProfileCompletionBanner.tsx` | Nuevo banner "Completa tu perfil" con acciones "Empezar" (abre `/complete-profile`) y "Ahora no" (dismiss) |
| `src/features/profile/components/ProfileWizard.tsx` | Wiring del marker: skip → dismiss, guardado exitoso → completed (nunca en error; secuencia de doble caché de WU2 intacta) |
| `src/features/dashboard/pages/DeveloperDashboard.tsx` | Monta el banner entre la card de usuario y las tabs |

Semántica: el banner aparece solo si el marker está ausente (primera vez), siempre ignorable, y desaparece de forma persistente por cualquiera de los tres caminos (dismiss, skip, o completar el wizard). Limitación aceptada por diseño: el marker es por navegador.

## Verificación

- `pnpm build` OK (chunk propio para el hook)
- `pnpm lint`: 32 errores, idéntico a línea base de main (cero nuevos)
- `pnpm test:e2e e2e/profile.spec.ts`: 6/6 verdes (no-regresión)
- Smokes descartables contra backend vivo: usuario nuevo ve banner → skip → banner desaparece sin PUT y persiste tras recarga; banner → guardado completo → banner desaparece con marker persistente (2/2)
- Revisión adversarial con contexto fresco: APROBADO, cero findings bloqueantes (verificó los tres caminos del marker, aislamiento por usuario sin flash pre-auth, y doble caché de WU2 sin cambios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)